### PR TITLE
Fix warnings in crtinit.c

### DIFF
--- a/mintlib/crtinit.c
+++ b/mintlib/crtinit.c
@@ -73,6 +73,7 @@
 #include <mint/osbind.h>
 #include <support.h>
 #include <string.h>
+#include <stdlib.h>
 #include "lib.h"
 #include "stksiz.h"
 


### PR DESCRIPTION
Warning was:
../mintlib/crtinit.c:101:2: warning: implicit declaration of function 'getenv' [-Wimplicit-function-declaration]
../mintlib/crtinit.c:101:9: warning: assignment makes pointer from integer without a cast [enabled by default]
Function `getenv' implicitly converted to pointer at ../mintlib/crtinit.c:101

This warning is fatal in Launchpad PPA builds for amd64.
Anyway, having this warning treated as error for cross-compilers
is a nonsense when the host system is 32-bit.