### PR TITLE
Force -fgnu89-inline (for new gcc versions)

### DIFF
--- a/configvars
+++ b/configvars
@@ -121,7 +121,7 @@ RANLIB=$(toolprefix)ranlib
 # ATTENTION: You have to optimize at least with -O, otherwise some
 # extern inlines will not work and will cause unresolved references
 # in certain modules.
-CFLAGS=-O2 -fomit-frame-pointer
+CFLAGS=-O2 -fomit-frame-pointer -fgnu89-inline
 
 # Flags for building executables
 LDFLAGS=


### PR DESCRIPTION
This fixes compilation with gcc 7.1 (somehow I have forgotten to publish it).