### PR TITLE
Several fixes, in separate commits

### DIFF
--- a/buildrules
+++ b/buildrules
@@ -110,12 +110,13 @@ SRCS := $(ARGPSRCS) $(CRYPTSRCS) $(DIRENTSRCS) $(GMPSRCS) $(LOGINSRCS) $(MINTLIB
 ifeq ($(libsize), _p)
 CFLAGS-_mon.S = -DPROFILING
 endif
-NOCFLAGS-crtinit.c = -pg -fomit-frame-pointer
-NOCFLAGS-gmon.c = -pg -fomit-frame-pointer
-NOCFLAGS-mcount.c = -pg -fomit-frame-pointer
-NOCFLAGS-profil-freq.c = -pg -fomit-frame-pointer
-NOCFLAGS-profil-posix.c = -pg -fomit-frame-pointer
-#NOCFLAGS-linea.c = -pg -fomit-frame-pointer -O2 -O
+CFLAGS-crtinit.c = -fno-omit-frame-pointer --no-profile
+CFLAGS-gmon.c = -fno-omit-frame-pointer --no-profile
+CFLAGS-mcount.c = -fno-omit-frame-pointer --no-profile
+CFLAGS-profil-freq.c = -fno-omit-frame-pointer --no-profile
+CFLAGS-profil-posix.c = -fno-omit-frame-pointer --no-profile
+#NOCFLAGS-linea.c = -O2 -O
+#CFLAGS-linea.c = -fno-omit-frame-pointer --no-profile
 #DEFS-vfscanf.c = -DNO_BUG_IN_ISO_C_CORRIGENDUM_1
 CFLAGS-localtime.c = -DUSG_COMPAT -DALL_STATE -DPCTS -DSTD_INSPIRED -DNOID -fwrapv
 CFLAGS-asctime.c = -DNOID

--- a/buildrules
+++ b/buildrules
@@ -127,6 +127,9 @@ CFLAGS-ivfprintf.c = -Wno-uninitialized
 DEFS-ident.c = -DVERSION=\"$(VERSION)\"
 DEFS-ident_sock.c = -DVERSION=\"$(VERSION)\"
 CFLAGS-crypt = -O3 -fexpensive-optimizations
+# This is necessary to avoid optimizing the sequence of malloc/memset
+# to a call to calloc in its own implementation
+CFLAGS-calloc.c = -fno-builtin
 # These source come from ... you know where
 DEFS-xbootparam_prot.c = -Wno-unused
 DEFS-xmount.c = -Wno-unused

--- a/buildrules
+++ b/buildrules
@@ -290,7 +290,9 @@ $(librpcsvc): $(RPCSVCOBJS)
 	@rm -f $@
 	$(AM_V_AR)$(AR) cru $@ $(RPCSVCOBJS)
 	$(AM_V_RANLIB)$(RANLIB) $@
-	
+
+$(LIBCOBJS) $(LIBIIO_ADDOBJS) $(RPCSVCOBJS): $(top_srcdir)/includepath
+
 $(top_srcdir)/include/linker.h: $(top_srcdir)/include/linker.h.in \
   $(top_srcdir)/configvars
 	(cd $(top_srcdir)/include && $(MAKE) linker.h)

--- a/buildrules
+++ b/buildrules
@@ -200,7 +200,7 @@ $(top_srcdir)/includepath: $(top_srcdir)/configvars
 	local= ; \
 	installdir=`$(CC) --print-search-dirs | awk '{ print $$2; exit; }'`; \
 	case $$installdir in /usr/local*) local=/local;; esac; \
-	echo "$${installdir}include -I$${installdir}include-fixed -I/usr$$local/m68k-atari-mint/include" >$@
+	echo "$${installdir}include -I$${installdir}include-fixed" >$@
 	@if [ -z "$$(<$@)" ]; then \
 	  rm $@; \
 	  echo "error: The syntax \$$(<file) is unsupported by $(SHELL)." >&2; \

--- a/configvars
+++ b/configvars
@@ -17,11 +17,17 @@ VERSION=0.60.1
 # Silent build or verbose
 AM_DEFAULT_VERBOSITY = 1
 
-# Define this to "m68k-atari-mint-" if you cross compile.
+# Define this to "m68k-atari-mint" if you cross compile.
+ifneq ($(CROSS_TOOL),)
+ toolprefix=$(CROSS_TOOL)-
+ CROSS := yes
+else
 ifeq ($(CROSS),yes)
- toolprefix=m68k-atari-mint-
+ CROSS_TOOL=m68k-atari-mint
+ toolprefix=$(CROSS_TOOL)-
 else
  toolprefix=
+endif
 endif
 
 # Uncomment this out if you want extra libraries that are optimized
@@ -47,7 +53,10 @@ WITH_V4E_LIB=yes
 # need be.  When cross-compiling you will usually want to set this
 # to "/usr/m68k-atari-mint".
 ifeq ($(CROSS),yes)
- prefix=/usr/m68k-atari-mint
+ prefix=$(shell $(toolprefix)gcc -print-sysroot)/usr
+  ifeq ($(prefix),)
+    prefix=/usr/$(CROSS_TOOL)
+  endif
 else
  prefix=/usr
 endif

--- a/crypt/crypt_util.c
+++ b/crypt/crypt_util.c
@@ -67,7 +67,7 @@ STATIC void shuffle_sb (long64 *k, ufc_long saltbits);
 # define int int32_t
 #endif
 
-static const char patchlevel_str[] = PATCHLEVEL;
+/* static const char patchlevel_str[] = PATCHLEVEL; */
 
 /*
  * Permutation done once on the 56 bit

--- a/crypt/des_impl.c
+++ b/crypt/des_impl.c
@@ -636,7 +636,7 @@ _des_crypt (char *buf, unsigned len, struct desparams *desp)
     }
   tin0 = tin1 = tout0 = tout1 = xor0 = xor1 = 0;
   tbuf[0] = tbuf[1] = 0;
-  __bzero (schedule, sizeof (schedule));
+  memset(schedule, 0, sizeof (schedule));
 
   return (1);
 }

--- a/crypt/md5.c
+++ b/crypt/md5.c
@@ -26,14 +26,8 @@
 
 #include <sys/types.h>
 
-#if STDC_HEADERS || defined _LIBC
 # include <stdlib.h>
 # include <string.h>
-#else
-# ifndef HAVE_MEMCPY
-#  define memcpy(d, s, n) bcopy ((s), (d), (n))
-# endif
-#endif
 
 #include "md5.h"
 

--- a/gmp/ldbl2mpn.c
+++ b/gmp/ldbl2mpn.c
@@ -26,6 +26,10 @@
 
 #ifndef __NO_LONG_DOUBLE_MATH
 
+#ifdef __mcoldfire__
+#  define NO_LONG_DOUBLE 1
+#endif
+
 /* Convert a `long double' in IEEE854 standard double-precision format to a
    multi-precision integer representing the significand scaled up by its
    number of bits (64 for long double) and an integral power of two
@@ -36,13 +40,21 @@ __mpn_extract_long_double (mp_ptr res_ptr, mp_size_t size,
 			   int *expt, int *is_neg,
 			   long double value)
 {
+#ifdef NO_LONG_DOUBLE
+  union ieee754_double u;
+#else
   union ieee854_long_double u;
+#endif
   u.d = value;
 
   (void) size;
 
   *is_neg = u.ieee.negative;
+#ifdef NO_LONG_DOUBLE
+  *expt = (int) u.ieee.exponent - IEEE754_DOUBLE_BIAS;
+#else
   *expt = (int) u.ieee.exponent - IEEE854_LONG_DOUBLE_BIAS;
+#endif
 
 #if BITS_PER_MP_LIMB == 32
   res_ptr[0] = u.ieee.mantissa1; /* Low-order 32 bits of fraction.  */
@@ -83,14 +95,22 @@ __mpn_extract_long_double (mp_ptr res_ptr, mp_size_t size,
 	          res_ptr[N - 1] <<= cnt;
 #endif
 		}
+#ifdef NO_LONG_DOUBLE
+	      *expt = DBL_MIN_EXP - 1 - cnt;
+#else
 	      *expt = LDBL_MIN_EXP - 1 - cnt;
+#endif
 	    }
 	  else
 	    {
 	      count_leading_zeros (cnt, res_ptr[0]);
 	      res_ptr[N - 1] = res_ptr[0] << cnt;
 	      res_ptr[0] = 0;
+#ifdef NO_LONG_DOUBLE
+	      *expt = DBL_MIN_EXP - 1 - BITS_PER_MP_LIMB - cnt;
+#else
 	      *expt = LDBL_MIN_EXP - 1 - BITS_PER_MP_LIMB - cnt;
+#endif
 	    }
 	}
     }

--- a/gmp/mpn-divmod_1.c
+++ b/gmp/mpn-divmod_1.c
@@ -205,4 +205,5 @@ mpn_divmod_1 (quot_ptr, dividend_ptr, dividend_size, divisor_limb)
 	}
       return r;
     }
+    (void) dummy;
 }

--- a/gmp/mpn-mod_1.c
+++ b/gmp/mpn-mod_1.c
@@ -194,4 +194,5 @@ mpn_mod_1 (dividend_ptr, dividend_size, divisor_limb)
 	}
       return r;
     }
+    (void) dummy;
 }

--- a/gmp/mpn2ldbl.c
+++ b/gmp/mpn2ldbl.c
@@ -24,6 +24,10 @@
 
 #ifndef __NO_LONG_DOUBLE_MATH
 
+#ifdef __mcoldfire__
+#  define NO_LONG_DOUBLE 1
+#endif
+
 /* Convert a multi-precision integer of the needed number of bits (64 for
    long double) and an integral power of two to a `long double' in IEEE854
    extended-precision format.  */
@@ -31,10 +35,18 @@
 long double
 __mpn_construct_long_double (mp_srcptr frac_ptr, int expt, int sign)
 {
+#ifdef NO_LONG_DOUBLE
+  union ieee754_double u;
+#else
   union ieee854_long_double u;
+#endif
 
   u.ieee.negative = sign;
+#ifdef NO_LONG_DOUBLE
+  u.ieee.exponent = expt + IEEE754_DOUBLE_BIAS;
+#else
   u.ieee.exponent = expt + IEEE854_LONG_DOUBLE_BIAS;
+#endif
 #if BITS_PER_MP_LIMB == 32
   u.ieee.mantissa1 = frac_ptr[0];
   u.ieee.mantissa0 = frac_ptr[1];

--- a/login/logout.c
+++ b/login/logout.c
@@ -50,9 +50,9 @@ logout (const char *line)
   if (getutline_r (&tmp, &utbuf, &ut) >= 0)
     {
       /* Clear information about who & from where.  */
-      __bzero (ut->ut_name, sizeof ut->ut_name);
+      memset(ut->ut_name, 0, sizeof ut->ut_name);
 #if _HAVE_UT_HOST - 0
-      __bzero (ut->ut_host, sizeof ut->ut_host);
+      memset (ut->ut_host, 0, sizeof ut->ut_host);
 #endif
 #if _HAVE_UT_TV - 0
       __gettimeofday (&ut->ut_tv, NULL);

--- a/login/oldutmp.c
+++ b/login/oldutmp.c
@@ -23,7 +23,7 @@ unsigned long time;
 	struct utmp entry;
 	int fd;
 
-	__bzero(&entry, sizeof(struct utmp));
+	memset(&entry, 0, sizeof(struct utmp));
 
 	if ((fd = open(UTMP_FILE, O_RDWR)) == -1)
 	{

--- a/mintlib/EXTRAFILES
+++ b/mintlib/EXTRAFILES
@@ -10,7 +10,7 @@
 SRCFILES += BINFILES EXTRAFILES MISCFILES Makefile SRCFILES SYSCALLS \
 _itoa.h math_private.h math_ldbl.h atomicity.h atomicity-68020.h errbase.h \
 gensys stksiz.h sysdep.h lib.h libc-symbols.h \
-machine-gmon.h memcopy.h profil-counter.h \
+machine-gmon.h memcopy.h profil-counter.h malloc_int.h \
 syscalls.h syscalls.list test-assert-perr.c test-assert.c test-atexit.c \
 test-atexit.expect test-ctype.c test-ctype1.c test-ctype1.expect \
 test-dirent.args test-dirent.c test-mallocbug.c test-seekdir.c test-setjmp.c \

--- a/mintlib/calloc.c
+++ b/mintlib/calloc.c
@@ -5,6 +5,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "lib.h"
+#include "malloc_int.h"
 
 void *
 __calloc (size_t n, size_t sz)

--- a/mintlib/calloc.c
+++ b/mintlib/calloc.c
@@ -16,7 +16,7 @@ __calloc (size_t n, size_t sz)
 
 	r = __malloc (total);
 	if (r != NULL)
-		__bzero (r, total);
+		memset(r, 0, total);
 
 	return r;
 }

--- a/mintlib/do_fstat.c
+++ b/mintlib/do_fstat.c
@@ -35,7 +35,7 @@ __sys_fstat (short fd, struct stat *st, int exact)
 
 			r = Fcntl (fd, &xattr, FSTAT);
 			if (r == 0) {
-				__bzero (st, sizeof (*st));
+				memset(st, 0, sizeof (*st));
 
 				st->st_dev = (dev_t) xattr.st_dev;
 				st->st_ino = (ino_t) xattr.st_ino;
@@ -96,7 +96,7 @@ __do_fstat (int fd, struct stat *st, int exact)
 	}
 
 	/* emulation for TOS */
-	__bzero (st, sizeof (*st));
+	memset(st, 0, sizeof (*st));
 
 	{
 		long oldplace;

--- a/mintlib/do_stat.c
+++ b/mintlib/do_stat.c
@@ -43,7 +43,7 @@ __sys_stat (const char *path, struct stat *st, int lflag, int exact)
 
 		r = Fxattr (lflag, path, &xattr);
 		if (r == 0) {
-			__bzero (st, sizeof (*st));
+			memset(st, 0, sizeof (*st));
 
 			st->st_dev = (__dev_t) xattr.st_dev;
 			st->st_ino = (__ino_t) xattr.st_ino;
@@ -154,7 +154,7 @@ __do_stat (const char *_path, struct stat *st, int lflag)
 	int	isdot = 0;
 	int	isdir = 0;
 
-	__bzero (st, sizeof (*st));
+	memset(st, 0, sizeof (*st));
 
 	/* otherwise, check to see if we have a name like CON: or AUX: */
 	if (nval == 1) {

--- a/mintlib/lib.h
+++ b/mintlib/lib.h
@@ -70,24 +70,6 @@ extern long _sigpending;
 
 extern int __current_umask;
 
-/* definitions needed in malloc.c and realloc.c */
-
-struct mem_chunk 
-{
-	long valid;
-#define VAL_FREE  0xf4ee0abcL
-#define VAL_ALLOC 0xa11c0abcL
-#define VAL_BORDER 0xb04d0abcL
-
-	struct mem_chunk *next;
-	unsigned long size;
-};
-#define ALLOC_SIZE(ch) (*(long *)((char *)(ch) + sizeof(*(ch))))
-#define BORDER_EXTRA ((sizeof(struct mem_chunk) + sizeof(long) + 7) & ~7)
-
-/* linked list of free blocks */
-extern struct mem_chunk _mchunk_free_list;
-
 
 /* status of open files (for isatty, et al.) */
 struct __open_file

--- a/mintlib/lib.h
+++ b/mintlib/lib.h
@@ -12,6 +12,17 @@
 #include <support.h>
 #include <sys/stat.h>	/* For struct stat.  */
 
+/*
+ * cast away const-ness.
+ * sometimes needed when the api requires a non-const return type
+ */
+#ifndef NO_CONST
+#  ifdef __GNUC__
+#	 define NO_CONST(p) __extension__({ union { const void *cs; void *s; } x; x.cs = p; x.s; })
+#  else
+#	 define NO_CONST(p) ((void *)(p))
+#  endif
+#endif
 
 int	_doprnt (int (*)(int, FILE *), FILE *, const char *, __gnuc_va_list);
 int	_scanf (FILE *, int (*)(FILE *), int (*)(int, FILE *), const char *, __gnuc_va_list);

--- a/mintlib/malloc.c
+++ b/mintlib/malloc.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <osbind.h>
 #include "lib.h"
+#include "malloc_int.h"
 
 
 /* CAUTION: use _mallocChunkSize() to tailor to your environment,
@@ -46,7 +47,7 @@ __malloc(size_t n)
 	unsigned long sz;
 
 	/* add a mem_chunk to required size and round up */
-	n = (n + sizeof(struct mem_chunk) + 7) & ~7;
+	n = (n + sizeof(struct mem_chunk) + (MALLOC_ALIGNMENT - 1)) & ~(MALLOC_ALIGNMENT - 1);
 
 	/* look for first block big enough in free list */
 	p = &_mchunk_free_list;

--- a/mintlib/malloc.c
+++ b/mintlib/malloc.c
@@ -132,7 +132,7 @@ __malloc(size_t n)
 	q++; /* hand back ptr to after chunk desc */
 
 	if (ZeroMallocs)
-		__bzero(q, (size_t)(n - sizeof(struct mem_chunk)));
+		memset(q, 0, (size_t)(n - sizeof(struct mem_chunk)));
 
 	return (void *) q;
 }

--- a/mintlib/malloc_int.h
+++ b/mintlib/malloc_int.h
@@ -1,0 +1,19 @@
+/* definitions needed in malloc.c and realloc.c */
+
+#define MALLOC_ALIGNMENT 8
+
+struct mem_chunk 
+{
+	long valid;
+#define VAL_FREE  0xf4ee0abcL
+#define VAL_ALLOC 0xa11c0abcL
+#define VAL_BORDER 0xb04d0abcL
+
+	struct mem_chunk *next;
+	unsigned long size;
+};
+#define ALLOC_SIZE(ch) (*(long *)((char *)(ch) + sizeof(*(ch))))
+#define BORDER_EXTRA ((sizeof(struct mem_chunk) + sizeof(long) + (MALLOC_ALIGNMENT - 1)) & ~(MALLOC_ALIGNMENT - 1))
+
+/* linked list of free blocks */
+extern struct mem_chunk _mchunk_free_list;

--- a/mintlib/math_ldbl.h
+++ b/mintlib/math_ldbl.h
@@ -2,8 +2,14 @@
 #error "Never use <math_ldbl.h> directly; include <math_private.h> instead."
 #endif
 
+#ifdef __mcoldfire__
+#  define NO_LONG_DOUBLE 1
+#endif
+
 /* A union which permits us to convert between a long double and
    four 32 bit ints or two 64 bit ints.  */
+
+#ifndef NO_LONG_DOUBLE
 
 #if __FLOAT_WORD_ORDER == BIG_ENDIAN
 
@@ -88,3 +94,5 @@ do {								\
   sh_u.value = (d);						\
   (v) = sh_u.parts64.lsw;					\
 } while (0)
+
+#endif /* __mcoldfire__ */

--- a/mintlib/mcount.c
+++ b/mintlib/mcount.c
@@ -44,6 +44,10 @@ static char sccsid[] = "@(#)mcount.c	8.1 (Berkeley) 6/4/93";
 
 #include <atomicity.h>
 
+#if __GNUC_PREREQ(4, 9)
+#pragma GCC diagnostic ignored "-Wframe-address"
+#endif
+
 /*
  * mcount is called on entry to each function compiled with the profiling
  * switch set.  _mcount(), which is declared in a machine-dependent way

--- a/mintlib/putenv.c
+++ b/mintlib/putenv.c
@@ -53,7 +53,7 @@ putenv(const char *strng)
 		if (!e) {
 			return -1;
 		}
-		__bcopy (environ, e, (i+1)*sizeof(char *));
+		memcpy(e, environ, (i+1)*sizeof(char *));
 		free(environ);
 		environ = e;
 	}

--- a/mintlib/quickstat.c
+++ b/mintlib/quickstat.c
@@ -67,7 +67,7 @@ __quickstat (const char *_path, struct stat *st, int lflag)
 	}
 
 	{
-	char	*ext, drv, *cwd, *prevdir = NULL;
+	char	*ext, drv, *prevdir = NULL;
 	_DTA	d;
 	_DTA	*olddta;
 	int	isdot = 0;

--- a/mintlib/quickstat.c
+++ b/mintlib/quickstat.c
@@ -73,7 +73,7 @@ __quickstat (const char *_path, struct stat *st, int lflag)
 	int	isdot = 0;
 	int	isdir = 0;
 	
-	__bzero (st, sizeof (*st));
+	memset(st, 0, sizeof (*st));
 	
 	/* Otherwise, check to see if we have a name like CON: or AUX: */
 	if (nval == 1) {

--- a/mintlib/realloc.c
+++ b/mintlib/realloc.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include "lib.h"
+#include "malloc_int.h"
 
 
 void *
@@ -32,9 +33,9 @@ __realloc (void *r, size_t n)
 	}
 
 	p = ((struct mem_chunk *) r) - 1;
-	sz = (n + sizeof(struct mem_chunk) + 7) & ~7;
+	sz = (n + sizeof(struct mem_chunk) + (MALLOC_ALIGNMENT - 1)) & ~(MALLOC_ALIGNMENT - 1);
 
-	if (p->size > (sz + ((2 * sizeof(struct mem_chunk) + 7) & ~7)))
+	if (p->size > (sz + ((2 * sizeof(struct mem_chunk) + (MALLOC_ALIGNMENT - 1)) & ~(MALLOC_ALIGNMENT - 1))))
 	{
 		/* resize down */
 		void *newr;

--- a/mintlib/realloc.c
+++ b/mintlib/realloc.c
@@ -42,8 +42,8 @@ __realloc (void *r, size_t n)
 		newr = __malloc(n);
 		if (newr)
 		{
-			__bcopy(r, newr, n);
-		        __free(r);
+			memcpy(newr, r, n);
+			__free(r);
 
 			r = newr;
 		}
@@ -84,8 +84,8 @@ __realloc (void *r, size_t n)
 			newr = __malloc(n);
 			if (newr)
 			{
-				__bcopy(r, newr, p->size - sizeof(struct mem_chunk));
-			        __free(r);
+				memcpy(newr, r, p->size - sizeof(struct mem_chunk));
+				__free(r);
 			}
 			r = newr;
 		}

--- a/mintlib/s_finitel.c
+++ b/mintlib/s_finitel.c
@@ -21,6 +21,7 @@
 #include "math.h"
 #include "math_private.h"
 
+#ifndef NO_LONG_DOUBLE
 int
 __finitel(long double x)
 {
@@ -30,3 +31,4 @@ __finitel(long double x)
 				 -0x7fff000000000000LL)>>63);
 }
 weak_alias (__finitel, finitel)
+#endif

--- a/mintlib/s_isinfl.c
+++ b/mintlib/s_isinfl.c
@@ -12,6 +12,7 @@
 #include "math.h"
 #include "math_private.h"
 
+#ifndef NO_LONG_DOUBLE
 int
 __isinfl (long double x)
 {
@@ -22,3 +23,4 @@ __isinfl (long double x)
 	return ~(lx >> 63) & (hx >> 62);
 }
 weak_alias (__isinfl, isinfl)
+#endif

--- a/mintlib/s_isnanl.c
+++ b/mintlib/s_isnanl.c
@@ -21,6 +21,7 @@
 #include "math.h"
 #include "math_private.h"
 
+#ifndef NO_LONG_DOUBLE
 int
 __isnanl (long double x)
 {
@@ -32,3 +33,4 @@ __isnanl (long double x)
 	return (int)((u_int64_t)hx>>63);
 }
 weak_alias (__isnanl, isnanl)
+#endif

--- a/mintlib/s_signbitl.c
+++ b/mintlib/s_signbitl.c
@@ -22,6 +22,7 @@
 
 #include "math_private.h"
 
+#ifndef NO_LONG_DOUBLE
 int
 __signbitl (long double x)
 {
@@ -31,3 +32,4 @@ __signbitl (long double x)
   return e < 0;
 }
 weak_alias (__signbitl, signbitl)
+#endif

--- a/mintlib/setenv.c
+++ b/mintlib/setenv.c
@@ -256,6 +256,7 @@ unsetenv (name)
 
   ep = __environ;
   if (ep != NULL)
+  {
     while (*ep != NULL)
       if (!strncmp (*ep, name, len) && (*ep)[len] == '=')
 	{
@@ -269,7 +270,8 @@ unsetenv (name)
 	}
       else
 	++ep;
-
+  }
+  
   UNLOCK;
 
   return 0;

--- a/mintlib/spawn.c
+++ b/mintlib/spawn.c
@@ -427,7 +427,7 @@ need_more_core:
 		*s++ = '\0';
 	}
 
-	__bzero(t = cmd, sizeof(cmd));
+	memset(t = cmd, 0, sizeof(cmd));
 
 /* s points at the environment's copy of the args */
 /* t points at the command line copy to be put in the basepage */

--- a/mintlib/towctrans.c
+++ b/mintlib/towctrans.c
@@ -234,12 +234,14 @@ static wchar_t __towcase(wchar_t wc, int lower)
 	 || (unsigned)wc - 0xa800 <= 0xfeff-0xa800)
 		return wc;
 	/* special case because the diff between upper/lower is too big */
-	if (lower && (unsigned)wc - 0x10a0 < 0x2e)
+	if (lower && (unsigned)wc - 0x10a0 < 0x2e) {
 		if (wc>0x10c5 && wc != 0x10c7 && wc != 0x10cd) return wc;
 		else return wc + 0x2d00 - 0x10a0;
-	if (!lower && (unsigned)wc - 0x2d00 < 0x26)
+	}
+	if (!lower && (unsigned)wc - 0x2d00 < 0x26) {
 		if (wc>0x2d25 && wc != 0x2d27 && wc != 0x2d2d) return wc;
 		else return wc + 0x10a0 - 0x2d00;
+	}
 	for (i=0; casemaps[i].len; i++) {
 		int base = casemaps[i].upper + (lmask & casemaps[i].lower);
 		if ((unsigned)wc-base < casemaps[i].len) {

--- a/misc/dirname.c
+++ b/misc/dirname.c
@@ -13,7 +13,7 @@
 
 #include "lib.h"
 
-#define my_tolower(c) ((c >= 'A' && c <= 'Z') ? c += ('a' - 'A') : c)
+#define my_tolower(c) (((c) >= 'A' && c <= 'Z') ? (c) + ('a' - 'A') : (c))
 
 char*
 dirname (char *path)

--- a/misc/mktemp.c
+++ b/misc/mktemp.c
@@ -25,7 +25,6 @@ mktemp (char* template)
   size_t len;
   pid_t pid = getpid ();
   unsigned int i0, i1, i2, j0, j1, j2;
-  int saved_errno;
   
   if (template == NULL)
     {
@@ -56,8 +55,6 @@ mktemp (char* template)
   i0 = Random () % sizeof __tmp_letters;
   i1 = Random () % sizeof __tmp_letters;
   i2 = Random () % sizeof __tmp_letters;
-  
-  saved_errno = errno;
   
   for (j0 = 0; j0 < sizeof __tmp_letters; j0++, i0++)
     {

--- a/misc/syslog.c
+++ b/misc/syslog.c
@@ -255,7 +255,7 @@ void openlog(ident, logstat, logfac)
 	{
 		memset(&SyslogAddr, 0, sizeof(SyslogAddr));
 		SyslogAddr.sin_family = AF_INET;
-		bcopy(hp->h_addr, (char *)&SyslogAddr.sin_addr, hp->h_length);
+		memcpy((char *)&SyslogAddr.sin_addr, hp->h_addr, hp->h_length);
 		SyslogAddr.sin_port = sp->s_port;
 		if (LogStat & LOG_NDELAY)
 			LogFile = socket(AF_INET, SOCK_DGRAM, 0);

--- a/misc/syslog.c
+++ b/misc/syslog.c
@@ -253,7 +253,7 @@ void openlog(ident, logstat, logfac)
 	hp = gethostbyname(LOG_HOST);
 	if (sp != NULL && hp != NULL)
 	{
-		bzero(&SyslogAddr, sizeof(SyslogAddr));
+		memset(&SyslogAddr, 0, sizeof(SyslogAddr));
 		SyslogAddr.sin_family = AF_INET;
 		bcopy(hp->h_addr, (char *)&SyslogAddr.sin_addr, hp->h_length);
 		SyslogAddr.sin_port = sp->s_port;

--- a/multibyte/mbrtowc.c
+++ b/multibyte/mbrtowc.c
@@ -13,13 +13,13 @@
 
 size_t mbrtowc(wchar_t *__restrict wc, const char *__restrict src, size_t n, mbstate_t *__restrict st)
 {
-	static unsigned internal_state;
+	static mbstate_t internal_state;
 	unsigned c;
 	const unsigned char *s = (const void *)src;
 	const unsigned N = n;
 
-	if (!st) st = (void *)&internal_state;
-	c = *(unsigned *)st;
+	if (!st) st = &internal_state;
+	c = st->__opaque1;
 	
 	if (!s) {
 		if (c) goto ilseq;
@@ -36,9 +36,9 @@ size_t mbrtowc(wchar_t *__restrict wc, const char *__restrict src, size_t n, mbs
 	if (n) {
 		if (OOB(c,*s)) goto ilseq;
 loop:
-		c = c<<6 | *s++-0x80; n--;
+		c = (c<<6) | (*s++-0x80); n--;
 		if (!(c&(1U<<31))) {
-			*(unsigned *)st = 0;
+			st->__opaque1 = 0;
 			*wc = c;
 			return N-n;
 		}
@@ -48,10 +48,10 @@ loop:
 		}
 	}
 
-	*(unsigned *)st = c;
+	st->__opaque1 = c;
 	return -2;
 ilseq:
-	*(unsigned *)st = 0;
+	st->__opaque1 = 0;
 	errno = EILSEQ;
 	return -1;
 }

--- a/multibyte/mbsrtowcs.c
+++ b/multibyte/mbsrtowcs.c
@@ -28,7 +28,7 @@ size_t mbsrtowcs(wchar_t *__restrict ws, const char **__restrict src, size_t wn,
 
 	if (!ws) for (;;) {
 		if (*s-1u < 0x7f && (uintptr_t)s%4 == 0) {
-			while (!(( *(uint32_t*)s | *(uint32_t*)s-0x01010101) & 0x80808080)) {
+			while (!(( *(const uint32_t*)s | (*(const uint32_t*)s-0x01010101)) & 0x80808080)) {
 				s += 4;
 				wn -= 4;
 			}
@@ -59,7 +59,7 @@ resume0:
 			return wn0;
 		}
 		if (*s-1u < 0x7f && (uintptr_t)s%4 == 0) {
-			while (wn>=5 && !(( *(uint32_t*)s | *(uint32_t*)s-0x01010101) & 0x80808080)) {
+			while (wn>=5 && !(( *(const uint32_t*)s | (*(const uint32_t*)s-0x01010101)) & 0x80808080)) {
 				*ws++ = *s++;
 				*ws++ = *s++;
 				*ws++ = *s++;
@@ -76,13 +76,13 @@ resume0:
 		c = bittab[*s++-SA];
 resume:
 		if (OOB(c,*s)) { s--; break; }
-		c = (c<<6) | *s++-0x80;
+		c = (c<<6) | (*s++-0x80);
 		if (c&(1U<<31)) {
 			if (*s-0x80u >= 0x40) { s-=2; break; }
-			c = (c<<6) | *s++-0x80;
+			c = (c<<6) | (*s++-0x80);
 			if (c&(1U<<31)) {
 				if (*s-0x80u >= 0x40) { s-=3; break; }
-				c = (c<<6) | *s++-0x80;
+				c = (c<<6) | (*s++-0x80);
 			}
 		}
 		*ws++ = c;

--- a/multibyte/mbtowc.c
+++ b/multibyte/mbtowc.c
@@ -30,21 +30,21 @@ int mbtowc(wchar_t *__restrict wc, const char *__restrict src, size_t n)
 	if (n<4 && ((c<<(6*n-6)) & (1U<<31))) goto ilseq;
 
 	if (OOB(c,*s)) goto ilseq;
-	c = c<<6 | *s++-0x80;
+	c = c<<6 | (*s++-0x80);
 	if (!(c&(1U<<31))) {
 		*wc = c;
 		return 2;
 	}
 
 	if (*s-0x80u >= 0x40) goto ilseq;
-	c = c<<6 | *s++-0x80;
+	c = c<<6 | (*s++-0x80);
 	if (!(c&(1U<<31))) {
 		*wc = c;
 		return 3;
 	}
 
 	if (*s-0x80u >= 0x40) goto ilseq;
-	*wc = c<<6 | *s++-0x80;
+	*wc = c<<6 | (*s++-0x80);
 	return 4;
 
 ilseq:

--- a/posix/glob.c
+++ b/posix/glob.c
@@ -131,53 +131,14 @@ extern int errno;
 # define REAL_DIR_ENTRY(dp) (dp->d_ino != 0)
 #endif /* POSIX */
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
 # include <stdlib.h>
 # include <string.h>
-# define	ANSI_STRING
-#else	/* No standard headers.  */
-
-extern char *getenv ();
-
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING
-# else
-#  include <strings.h>
-# endif
-# ifdef	HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-
-extern char *malloc (), *realloc ();
-extern void free ();
-
-extern void qsort ();
-extern void abort (), exit ();
-
-#endif	/* Standard headers.  */
 
 #ifdef HAVE_GETLOGIN_R
 extern int getlogin_r __P ((char *, size_t));
 #else
 extern char *getlogin __P ((void));
 #endif
-
-#ifndef	ANSI_STRING
-
-# ifndef bzero
-extern void bzero ();
-# endif
-# ifndef bcopy
-extern void bcopy ();
-# endif
-
-# define memcpy(d, s, n)	bcopy ((s), (d), (n))
-# define strrchr	rindex
-/* memset is only used for zero here, but let's be paranoid.  */
-# define memset(s, better_be_zero, n) \
-  ((void) ((better_be_zero) == 0 ? (bzero((s), (n)), 0) : (abort(), 0)))
-#endif	/* Not ANSI_STRING.  */
 
 #if !defined HAVE_STRCOLL && !defined _LIBC
 # define strcoll	strcmp

--- a/posix/regex.c
+++ b/posix/regex.c
@@ -4895,6 +4895,8 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
             POP_FAILURE_POINT (sdummy, pdummy,
                                dummy_low_reg, dummy_high_reg,
                                reg_dummy, reg_dummy, reg_info_dummy);
+            (void) sdummy;
+            (void) pdummy;
           }
 	  /* Note fall through.  */
 

--- a/posix/regex.c
+++ b/posix/regex.c
@@ -48,10 +48,6 @@
 # include <sys/types.h>
 #endif
 
-#ifdef __MINT__
-extern void __bzero PARAMS ((void*, size_t));
-#endif
-
 #define WIDE_CHAR_SUPPORT (HAVE_WCTYPE_H && HAVE_WCHAR_H && HAVE_BTOWC)
 
 /* For platform which support the ISO C amendement 1 functionality we
@@ -122,39 +118,7 @@ char *malloc ();
 char *realloc ();
 # endif
 
-/* When used in Emacs's lib-src, we need to get bzero and bcopy somehow.
-   If nothing else has been done, use the method below.  */
-# ifdef INHIBIT_STRING_HEADER
-#  if !(defined HAVE_BZERO && defined HAVE_BCOPY)
-#   if !defined bzero && !defined bcopy
-#    undef INHIBIT_STRING_HEADER
-#   endif
-#  endif
-# endif
-
-/* This is the normal way of making sure we have a bcopy and a bzero.
-   This is used in most programs--a few other programs avoid this
-   by defining INHIBIT_STRING_HEADER.  */
-# ifndef INHIBIT_STRING_HEADER
-#  if defined HAVE_STRING_H || defined STDC_HEADERS || defined _LIBC
-#   include <string.h>
-#   ifndef bzero
-#    ifndef _LIBC
-#     define bzero(s, n)	(memset (s, '\0', n), (s))
-#    else
-#     define bzero(s, n)	__bzero (s, n)
-#    endif
-#   endif
-#  else
-#   include <strings.h>
-#   ifndef memcmp
-#    define memcmp(s1, s2, n)	bcmp (s1, s2, n)
-#   endif
-#   ifndef memcpy
-#    define memcpy(d, s, n)	(bcopy (s, d, n), (d))
-#   endif
-#  endif
-# endif
+# include <string.h>
 
 /* Define the syntax stuff for \<, \>, etc.  */
 
@@ -270,7 +234,7 @@ init_syntax_once ()
 
    if (done)
      return;
-   bzero (re_syntax_table, sizeof re_syntax_table);
+   memset(re_syntax_table, 0, sizeof re_syntax_table);
 
    for (c = 0; c < CHAR_SET_SIZE; ++c)
      if (ISALNUM (c))
@@ -2206,7 +2170,7 @@ regex_compile (pattern, size, syntax, bufp)
             BUF_PUSH ((1 << BYTEWIDTH) / BYTEWIDTH);
 
             /* Clear the whole map.  */
-            bzero (b, (1 << BYTEWIDTH) / BYTEWIDTH);
+            memset(b, 0, (1 << BYTEWIDTH) / BYTEWIDTH);
 
             /* charset_not matches newline according to a syntax bit.  */
             if ((re_opcode_t) b[-2] == charset_not
@@ -3243,7 +3207,7 @@ re_compile_fastmap (bufp)
   assert (fastmap != NULL && p != NULL);
 
   INIT_FAIL_STACK ();
-  bzero (fastmap, 1 << BYTEWIDTH);  /* Assume nothing's valid.  */
+  memset(fastmap, 0, 1 << BYTEWIDTH);  /* Assume nothing's valid.  */
   bufp->fastmap_accurate = 1;	    /* It will be when we're done.  */
   bufp->can_be_null = 0;
 

--- a/posix/wordexp.c
+++ b/posix/wordexp.c
@@ -2143,7 +2143,6 @@ wordfree (wordexp_t *pwordexp)
 int
 wordexp (const char *words, wordexp_t *pwordexp, int flags)
 {
-  size_t wordv_offset;
   size_t words_offset;
   size_t word_length;
   size_t max_length;
@@ -2185,7 +2184,7 @@ wordexp (const char *words, wordexp_t *pwordexp, int flags)
   if ((flags & WRDE_APPEND) == 0)
     pwordexp->we_wordc = 0;
 
-  wordv_offset = pwordexp->we_offs + pwordexp->we_wordc;
+  /* wordv_offset = pwordexp->we_offs + pwordexp->we_wordc; */
 
   /* Find out what the field separators are.
    * There are two types: whitespace and non-whitespace.

--- a/signal/sigwait.c
+++ b/signal/sigwait.c
@@ -41,12 +41,12 @@ __sigwait (const sigset_t *set, int *sig)
   int this;
 
   /* Prepare set.  */
-  __sigfillset (&tmp_mask);
+  (void) __sigfillset (&tmp_mask);
 
   /* Unblock all signals in the SET and register our nice handler.  */
   action.sa_handler = ignore_signal;
   action.sa_flags = 0;
-  __sigfillset (&action.sa_mask);	/* Block all signals for handler.  */
+  (void) __sigfillset (&action.sa_mask);	/* Block all signals for handler.  */
 
   /* Make sure we recognize error conditions by setting WAS_SIG to a
      value which does not describe a legal signal number.  */

--- a/socket/gethostnamadr.c
+++ b/socket/gethostnamadr.c
@@ -276,9 +276,9 @@ reorder_addrs (struct hostent *h)
 		for ( itp = itab, cnt=numitab; cnt; itp++,cnt--) {	/* loop though the interfaces */
 			if (( (*r)->s_addr & itp->netmask) == itp->address) {	/* compare */
 				/* We found a match.  Swap it into [0] */
-				bcopy( ((struct in_addr **) (h->h_addr_list))[0],    &tmp, sizeof(tmp));
-				bcopy( (*r),    ((struct in_addr **) (h->h_addr_list))[0], sizeof(tmp));
-				bcopy( &tmp,                                      (*r), sizeof(tmp));
+				memcpy(&tmp, ((struct in_addr **) (h->h_addr_list))[0], sizeof(tmp));
+				memcpy(((struct in_addr **) (h->h_addr_list))[0], (*r), sizeof(tmp));
+				memcpy((*r),                                      &tmp, sizeof(tmp));
 
 				return;	/* found one, don't need to continue */
 			}
@@ -607,7 +607,7 @@ getanswer (querybuf *answer, int anslen, int iquery)
 #endif
 			break;
 		}
-		bcopy(cp, *hap++ = bp, n);
+		memcpy(*hap++ = bp, cp, n);
 		bp +=n;
 		cp += n;
 		haveanswer++;
@@ -1010,7 +1010,7 @@ _gethtbyname (char *name)
 
 			if(n<=htbuflen){
 				/* add the found address to the list */
-				bcopy(p->h_addr_list[0], bp, n);
+				memcpy(bp, p->h_addr_list[0], n);
 				*hap++=bp;
 				*hap=NULL;
 				bp+=n;
@@ -1022,7 +1022,7 @@ _gethtbyname (char *name)
 			int n = p->h_length;
 			if(n<=locbuflen){
 				/* add the found local address to the list */
-				bcopy(p->h_addr_list[0], lbp, n);
+				memcpy(lbp, p->h_addr_list[0], n);
 				*lhap++=lbp;
 				*lhap=NULL;
 				lbp+=n;
@@ -1059,10 +1059,10 @@ _gethtbyname (char *name)
 				/* FIXME: What is h good for?  */
 				u_long t, l, h = 0;
 				/* assert(sizeof(u_long)>=ht.h_length); */
-				bcopy(loc_addr_ptrs[i], (char *)&t,
+				memcpy((char *)&t, loc_addr_ptrs[i],
 					ht.h_length);
 				l=ntohl(t);
-				bcopy(ht_addr_ptrs[j], (char *)&t, 
+				memcpy((char *)&t, ht_addr_ptrs[j],
 					ht.h_length);
 				t=l^h;
 

--- a/socket/inet_makeaddr.c
+++ b/socket/inet_makeaddr.c
@@ -51,16 +51,16 @@ static char sccsid[] = "@(#)inet_makeaddr.c	5.6 (Berkeley) 2/24/91";
 struct in_addr
 inet_makeaddr (in_addr_t net, in_addr_t host)
 {
-	u_long addr;
+	struct in_addr addr;
 
 	if (net < 128)
-		addr = (net << IN_CLASSA_NSHIFT) | (host & IN_CLASSA_HOST);
+		addr.s_addr = (net << IN_CLASSA_NSHIFT) | (host & IN_CLASSA_HOST);
 	else if (net < 65536)
-		addr = (net << IN_CLASSB_NSHIFT) | (host & IN_CLASSB_HOST);
+		addr.s_addr = (net << IN_CLASSB_NSHIFT) | (host & IN_CLASSB_HOST);
 	else if (net < 16777216L)
-		addr = (net << IN_CLASSC_NSHIFT) | (host & IN_CLASSC_HOST);
+		addr.s_addr = (net << IN_CLASSC_NSHIFT) | (host & IN_CLASSC_HOST);
 	else
-		addr = net | host;
-	addr = htonl(addr);
-	return (*(struct in_addr *)&addr);
+		addr.s_addr = net | host;
+	addr.s_addr = htonl(addr.s_addr);
+	return addr;
 }

--- a/socket/rcmd.c
+++ b/socket/rcmd.c
@@ -100,7 +100,7 @@ rcmd(ahost, rport, locuser, remuser, cmd, fd2p)
 		fcntl(s, F_SETOWN, pid);
 #endif
 		sin.sin_family = hp->h_addrtype;
-		bcopy(hp->h_addr_list[0], (caddr_t)&sin.sin_addr, hp->h_length);
+		memcpy((caddr_t)&sin.sin_addr, hp->h_addr_list[0], hp->h_length);
 		sin.sin_port = rport;
 		if (connect(s, (struct sockaddr *)&sin, sizeof(sin)) >= 0)
 			break;
@@ -122,7 +122,7 @@ rcmd(ahost, rport, locuser, remuser, cmd, fd2p)
 			__set_errno (oerrno);
 			perror(0);
 			hp->h_addr_list++;
-			bcopy(hp->h_addr_list[0], (caddr_t)&sin.sin_addr,
+			memcpy(&sin.sin_addr, hp->h_addr_list[0],
 			    hp->h_length);
 			fprintf(stderr, "Trying %s...\n",
 				inet_ntoa(sin.sin_addr));

--- a/socket/res_debug.c
+++ b/socket/res_debug.c
@@ -242,7 +242,7 @@ p_rr(cp, msg, file)
 		switch (class) {
 		case C_IN:
 		case C_HS:
-			bcopy(cp, (char *)&inaddr, sizeof(inaddr));
+			memcpy((char *)&inaddr, cp, sizeof(inaddr));
 			if (dlen == 4) {
 				fprintf(file,"\tinternet address = %s\n",
 					inet_ntoa(inaddr));
@@ -345,7 +345,7 @@ p_rr(cp, msg, file)
 	case T_WKS:
 		if (dlen < sizeof(u_long) + 1)
 			break;
-		bcopy(cp, (char *)&inaddr, sizeof(inaddr));
+		memcpy((char *)&inaddr, cp, sizeof(inaddr));
 		cp += sizeof(u_long);
 		fprintf(file,"\tinternet address = %s, protocol = %d\n\t",
 			inet_ntoa(inaddr), *cp++);

--- a/socket/res_mkquery.c
+++ b/socket/res_mkquery.c
@@ -143,7 +143,7 @@ res_mkquery(op, dname, class, type, data, datalen, newrr, buf, buflen)
 		__putshort(datalen, (u_char *)cp);
 		cp += sizeof(u_short);
 		if (datalen) {
-			bcopy(data, cp, datalen);
+			memcpy(cp, data, datalen);
 			cp += datalen;
 		}
 		hp->ancount = htons(1);
@@ -177,7 +177,7 @@ res_mkquery(op, dname, class, type, data, datalen, newrr, buf, buflen)
 		__putshort(datalen, cp);
                 cp += sizeof(u_short);
 		if (datalen) {
-			bcopy(data, cp, datalen);
+			memcpy(cp, data, datalen);
 			cp += datalen;
 		}
 		if ( (op == UPDATED) || (op == UPDATEDA) ) {
@@ -200,7 +200,7 @@ res_mkquery(op, dname, class, type, data, datalen, newrr, buf, buflen)
 		__putshort(newrr->r_size, cp);
                 cp += sizeof(u_short);
 		if (newrr->r_size) {
-			bcopy(newrr->r_data, cp, newrr->r_size);
+			memcpy(cp, newrr->r_data, newrr->r_size);
 			cp += newrr->r_size;
 		}
 		hp->ancount = htons(0);

--- a/socket/res_mkquery.c
+++ b/socket/res_mkquery.c
@@ -75,7 +75,7 @@ res_mkquery(op, dname, class, type, data, datalen, newrr, buf, buflen)
 	 */
 	if ((buf == NULL) || (buflen < sizeof(HEADER)))
 		return(-1);
-	bzero(buf, sizeof(HEADER));
+	memset(buf, 0, sizeof(HEADER));
 	hp = (HEADER *) buf;
 	hp->id = htons(++_res.id);
 	hp->opcode = op;

--- a/socket/res_query.c
+++ b/socket/res_query.c
@@ -246,7 +246,7 @@ res_querydomain(name, domain, class, type, answer, anslen)
 		 */
 		n = strlen(name) - 1;
 		if (name[n] == '.' && n < sizeof(nbuf) - 1) {
-			bcopy(name, nbuf, n);
+			memcpy(nbuf, name, n);
 			nbuf[n] = '\0';
 		} else
 			longname = name;

--- a/socket/res_send.c
+++ b/socket/res_send.c
@@ -65,7 +65,7 @@ static struct sockaddr no_addr;
 #define	FD_SET(n, p)	((p)->fds_bits[(n)/NFDBITS] |= (1 << ((n) % NFDBITS)))
 #define	FD_CLR(n, p)	((p)->fds_bits[(n)/NFDBITS] &= ~(1 << ((n) % NFDBITS)))
 #define	FD_ISSET(n, p)	((p)->fds_bits[(n)/NFDBITS] & (1 << ((n) % NFDBITS)))
-#define FD_ZERO(p)	bzero((char *)(p), sizeof(*(p)))
+#define FD_ZERO(p)	memset((char *)(p), 0, sizeof(*(p)))
 #endif
 
 int

--- a/stdio/doprnt.c
+++ b/stdio/doprnt.c
@@ -41,7 +41,7 @@ _doprnt (putfunc* putf, FILE* stream,
 	int retval;
 	struct doprnt_arg doprnt_args = { putf, stream };
 	
-	__bzero ((void*) &file, sizeof (file));
+	memset((void*) &file, 0, sizeof (file));
 	file.__magic = _IOMAGIC;
 	file.__mode.__write = 1;
 	file.__bufp = file.__buffer = buf;

--- a/stdio/fputc.c
+++ b/stdio/fputc.c
@@ -21,6 +21,10 @@
 #include <errno.h>
 #include <stdio.h>
 
+#if __GNUC_PREREQ(7, 0)
+# pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+
 /* Write the character C to STREAM.  */
 int
 fputc (c, stream)

--- a/stdio/fwrite.c
+++ b/stdio/fwrite.c
@@ -21,6 +21,10 @@
 #include <string.h>
 
 
+#if __GNUC_PREREQ(7, 0)
+# pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+
 /* Write NMEMB chunks of SIZE bytes each from PTR onto STREAM.  */
 size_t
 fwrite (ptr, size, nmemb, stream)

--- a/stdio/obstream.c
+++ b/stdio/obstream.c
@@ -116,7 +116,7 @@ seek (void *cookie, fpos_t *pos, int whence)
   if (delta > 0)
     {
       obstack_blank (obstack, delta);
-      bzero (obstack_base (obstack) + current_offset, delta);
+      memset(obstack_base (obstack) + current_offset, 0, delta);
     }
 
   return 0;
@@ -174,7 +174,7 @@ obstack_vprintf (struct obstack *obstack, const char *format, va_list args)
 {
   int result;
   FILE f;
-  bzero (&f, sizeof (f));
+  memset(&f, 0, sizeof (f));
   init_obstream (&f, obstack);
   result = vfprintf (&f, format, args);
 

--- a/stdio/printf_fp.c
+++ b/stdio/printf_fp.c
@@ -695,6 +695,7 @@ __printf_fp (FILE *fp,
 			}
 		    }
 		  used_limbs = fracsize - 1;
+		  (void) used_limbs;
 		}
 	    }
 	  --explog;

--- a/stdio/psignal.c
+++ b/stdio/psignal.c
@@ -42,7 +42,7 @@ psignal (int sig, const char *s)
 {
   const char *colon, *desc;
 
-  if (s == NULL || s == '\0')
+  if (s == NULL || *s == '\0')
     s = colon = "";
   else
     colon = ": ";

--- a/stdio/tempnam.c
+++ b/stdio/tempnam.c
@@ -30,7 +30,6 @@ tempnam (const char* dir, const char* prefix)
   static char buf[L_tmpnam];
   pid_t pid = getpid ();
   unsigned int i0, i1, i2, j0, j1, j2;
-  int saved_errno;
   size_t len;
   char* tmpdir = (char*) (dir == NULL || (strlen (dir) > L_tmpnam - 13) ? 
   				__get_tmpdir (NULL, 1)
@@ -74,8 +73,6 @@ tempnam (const char* dir, const char* prefix)
   i0 = Random () % sizeof __tmp_letters;
   i1 = Random () % sizeof __tmp_letters;
   i2 = Random () % sizeof __tmp_letters;
-
-  saved_errno = errno;
 
   for (j0 = 0; j0 < sizeof __tmp_letters; j0++, i0++)
     {

--- a/stdio/vfprintf.c
+++ b/stdio/vfprintf.c
@@ -38,6 +38,10 @@
 # include <string.h>
 #endif
 
+#if __GNUC_PREREQ(7, 0)
+# pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+
 /* This code is shared between the standard stdio implementation found
    in GNU C library and the libio implementation originally found in
    GNU libg++.

--- a/stdlib/bsearch.c
+++ b/stdlib/bsearch.c
@@ -40,8 +40,8 @@ void * bsearch(key, base, num, size, cmp)
 			{
 			if (dir < 0)
 			{
-			    if (c == 0)
-				return(NULL);
+				if (c == 0)
+					return(NULL);
 				b = c - 1;
 			}
 			else /* (dir > 0) */

--- a/stdlib/strtod.c
+++ b/stdlib/strtod.c
@@ -106,6 +106,11 @@
 # include <wctype.h>
 # define STRING_TYPE wchar_t
 # define CHAR_TYPE wint_t
+/* We should get wint_t from <stddef.h>, but not all GCC versions define it
+   there.  So define it ourselves if it remains undefined.  */
+#ifndef _WINT_T
+  typedef unsigned int wint_t;
+#endif
 # define L_(Ch) L##Ch
 # ifdef USE_IN_EXTENDED_LOCALE_MODEL
 #  define ISSPACE(Ch) __iswspace_l ((Ch), loc)
@@ -485,11 +490,6 @@ INTERNAL (STRTOF) (nptr, endptr, group LOCALE_PARAM)
   /* Contains the last character read.  */
   CHAR_TYPE c;
 
-/* We should get wint_t from <stddef.h>, but not all GCC versions define it
-   there.  So define it ourselves if it remains undefined.  */
-#ifndef _WINT_T
-  typedef unsigned int wint_t;
-#endif
   /* The radix character of the current locale.  */
   wchar_t decimal;
   /* The thousands character of the current locale.  */

--- a/stdlib/strtold.c
+++ b/stdlib/strtold.c
@@ -4,7 +4,7 @@
 
 #include <math.h>
 
-#ifndef __NO_LONG_DOUBLE_MATH
+#if !defined(__NO_LONG_DOUBLE_MATH) && !defined(__mcoldfire__)
 /* The actual implementation for all floating point sizes is in strtod.c.
    These macros tell it to produce the `long double' version, `strtold'.  */
 
@@ -31,6 +31,9 @@
 
 #else
 # include <stdlib.h>
+
+double __strtod_internal (const char *nptr, char **endptr, int group);
+
 /* There is no `long double' type, use the `double' implementations.  */
 long double
 __strtold_internal (const char *nptr, char **endptr, int group)

--- a/string/strchrnul.c
+++ b/string/strchrnul.c
@@ -66,7 +66,7 @@ __strchrnul (s, c_in)
   switch (sizeof (longword))
     {
     case 4: magic_bits = 0x7efefeffL; break;
-    case 8: magic_bits = ((0x7efefefeL << 16) << 16) | 0xfefefeffL; break;
+    case 8: magic_bits = (unsigned long)0x7efefefefefefeffULL; break;
     default:
       abort ();
     }

--- a/string/strcmp.c
+++ b/string/strcmp.c
@@ -5,6 +5,10 @@
 #include <string.h>
 #undef strcmp
 
+#if __GNUC_PREREQ(7, 0)
+# pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+
 /*
  * strcmp - compare string s1 to s2
  */

--- a/string/strlen.c
+++ b/string/strlen.c
@@ -2,6 +2,10 @@
 #include <string.h>
 #undef strlen
 
+#if __GNUC_PREREQ(7, 0)
+# pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+
 /*
  * strlen - length of string (not including NUL)
  */

--- a/string/strncmp.c
+++ b/string/strncmp.c
@@ -6,6 +6,10 @@
 
 #undef strncmp
 
+#if __GNUC_PREREQ(7, 0)
+# pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+
 /*
  * strncmp - compare at most n characters of string s1 to s2
  */

--- a/string/strstr.c
+++ b/string/strstr.c
@@ -9,9 +9,7 @@
  */
 
 char *				/* found string, or NULL if none */
-strstr(s, wanted)
-const char *s;
-const char *wanted;
+strstr(const char *s, const char *wanted)
 {
 	register const char *scan;
 	register size_t len;

--- a/sunrpc/bindrsvprt.c
+++ b/sunrpc/bindrsvprt.c
@@ -57,7 +57,7 @@ bindresvport (int sd, struct sockaddr_in *sin)
   if (sin == (struct sockaddr_in *) 0)
     {
       sin = &myaddr;
-      __bzero (sin, sizeof (*sin));
+      memset(sin, 0, sizeof (*sin));
       sin->sin_family = AF_INET;
     }
   else if (sin->sin_family != AF_INET)

--- a/sunrpc/clnt_gen.c
+++ b/sunrpc/clnt_gen.c
@@ -127,7 +127,7 @@ clnt_create (const char *hostname, u_long prog, u_long vers,
   sin.sin_family = h->h_addrtype;
   sin.sin_port = 0;
   memset(sin.sin_zero, 0, sizeof (sin.sin_zero));
-  bcopy (h->h_addr, (char *) &sin.sin_addr, h->h_length);
+  memcpy((char *) &sin.sin_addr, h->h_addr, h->h_length);
 
 #ifndef __MINT__
   prtbuflen = 1024;

--- a/sunrpc/clnt_gen.c
+++ b/sunrpc/clnt_gen.c
@@ -71,7 +71,7 @@ clnt_create (const char *hostname, u_long prog, u_long vers,
 
   if (strcmp (proto, "unix") == 0)
     {
-      __bzero ((char *)&sun, sizeof (sun));
+      memset((char *)&sun, 0, sizeof (sun));
       sun.sun_family = AF_UNIX;
       strcpy (sun.sun_path, hostname);
       sock = RPC_ANYSOCK;
@@ -126,7 +126,7 @@ clnt_create (const char *hostname, u_long prog, u_long vers,
     }
   sin.sin_family = h->h_addrtype;
   sin.sin_port = 0;
-  __bzero (sin.sin_zero, sizeof (sin.sin_zero));
+  memset(sin.sin_zero, 0, sizeof (sin.sin_zero));
   bcopy (h->h_addr, (char *) &sin.sin_addr, h->h_length);
 
 #ifndef __MINT__

--- a/sunrpc/clnt_perr.c
+++ b/sunrpc/clnt_perr.c
@@ -42,6 +42,7 @@ static char sccsid[] = "@(#)clnt_perror.c 1.15 87/10/07 Copyr 1984 Sun Micro";
 #include <rpc/types.h>
 #include <rpc/auth.h>
 #include <rpc/clnt.h>
+#include "lib.h"
 
 #ifdef __MINT__
 /* no intl support in mintlib yet */
@@ -272,10 +273,10 @@ clnt_sperrno (enum clnt_stat stat)
     {
       if (rpc_errlist[i].status == stat)
 	{
-	  return _(rpc_errstr + rpc_errlist[i].message_off);
+	  return (char *)NO_CONST(_(rpc_errstr + rpc_errlist[i].message_off));
 	}
     }
-  return _("RPC: (unknown error code)");
+  return (char *)NO_CONST(_("RPC: (unknown error code)"));
 }
 
 void
@@ -385,7 +386,7 @@ auth_errmsg (enum auth_stat stat)
     {
       if (auth_errlist[i].status == stat)
 	{
-	  return _(auth_errstr + auth_errlist[i].message_off);
+	  return (char *)NO_CONST(_(auth_errstr + auth_errlist[i].message_off));
 	}
     }
   return NULL;

--- a/sunrpc/clnt_simp.c
+++ b/sunrpc/clnt_simp.c
@@ -132,7 +132,7 @@ callrpc (const char *host, u_long prognum, u_long versnum, u_long procnum,
 
       timeout.tv_usec = 0;
       timeout.tv_sec = 5;
-      bcopy (hp->h_addr, (char *) &server_addr.sin_addr, hp->h_length);
+      memcpy((char *) &server_addr.sin_addr, hp->h_addr, hp->h_length);
       server_addr.sin_family = AF_INET;
       server_addr.sin_port = 0;
       if ((crp->client = clntudp_create (&server_addr, (u_long) prognum,

--- a/sunrpc/create_xid.c
+++ b/sunrpc/create_xid.c
@@ -35,7 +35,7 @@ static struct drand48_data __rpc_lrand48_data;
 unsigned long
 _create_xid (void)
 {
-  unsigned long res;
+  long res;
 
   __libc_lock_lock (createxid_lock);
 

--- a/sunrpc/getrpcport.c
+++ b/sunrpc/getrpcport.c
@@ -76,7 +76,7 @@ getrpcport (const char *host, u_long prognum, u_long versnum, u_int proto)
     return 0;
 #endif
 
-  bcopy (hp->h_addr, (char *) &addr.sin_addr, hp->h_length);
+  memcpy((char *) &addr.sin_addr, hp->h_addr, hp->h_length);
   addr.sin_family = AF_INET;
   addr.sin_port = 0;
   return pmap_getport (&addr, prognum, versnum, proto);

--- a/sunrpc/key_call.c
+++ b/sunrpc/key_call.c
@@ -210,7 +210,7 @@ key_gendes (des_block *key)
   sin.sin_family = AF_INET;
   sin.sin_port = 0;
   sin.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
-  __bzero (sin.sin_zero, sizeof (sin.sin_zero));
+  memset(sin.sin_zero, 0, sizeof (sin.sin_zero));
   socket = RPC_ANYSOCK;
   client = clntudp_bufcreate (&sin, (u_long) KEY_PROG, (u_long) KEY_VERS,
 			      trytimeout, &socket, RPCSMALLMSGSIZE,

--- a/sunrpc/key_call.c
+++ b/sunrpc/key_call.c
@@ -374,7 +374,7 @@ getkeyserv_handle (int vers)
   struct timeval wait_time;
   int fd;
   struct sockaddr_un name;
-  int namelen = sizeof(struct sockaddr_un);
+  socklen_t namelen = sizeof(struct sockaddr_un);
 
 #define TOTAL_TIMEOUT   30      /* total timeout talking to keyserver */
 #define TOTAL_TRIES     5       /* Number of tries */

--- a/sunrpc/openchild.c
+++ b/sunrpc/openchild.c
@@ -86,7 +86,7 @@ _openchild (const char *command, FILE ** fto, FILE ** ffrom)
       for (i = _rpc_dtablesize () - 1; i >= 3; i--)
 	__close (i);
       fflush (stderr);
-      execlp (command, command, 0);
+      execlp (command, command, (const char *)0);
       perror ("exec");
       _exit (~0);
 

--- a/sunrpc/pmap_rmt.c
+++ b/sunrpc/pmap_rmt.c
@@ -289,7 +289,7 @@ clnt_broadcast (prog, vers, proc, xargs, argsp, xresults, resultsp, eachresult)
   fd.fd = sock;
   fd.events = POLLIN;
   nets = getbroadcastnets (addrs, sock, inbuf);
-  __bzero ((char *) &baddr, sizeof (baddr));
+  memset((char *) &baddr, 0, sizeof (baddr));
   baddr.sin_family = AF_INET;
   baddr.sin_port = htons (PMAPPORT);
   baddr.sin_addr.s_addr = htonl (INADDR_ANY);

--- a/sunrpc/rpc_cmsg.c
+++ b/sunrpc/rpc_cmsg.c
@@ -82,7 +82,7 @@ xdr_callmsg (XDR *xdrs, struct rpc_msg *cmsg)
 	  IXDR_PUT_INT32 (buf, oa->oa_length);
 	  if (oa->oa_length)
 	    {
-	      bcopy (oa->oa_base, (caddr_t) buf, oa->oa_length);
+	      memcpy(buf, oa->oa_base, oa->oa_length);
 	      buf = (int32_t *) ((char *) buf + RNDUP (oa->oa_length));
 	    }
 	  oa = &cmsg->rm_call.cb_verf;
@@ -90,7 +90,7 @@ xdr_callmsg (XDR *xdrs, struct rpc_msg *cmsg)
 	  IXDR_PUT_INT32 (buf, oa->oa_length);
 	  if (oa->oa_length)
 	    {
-	      bcopy (oa->oa_base, (caddr_t) buf, oa->oa_length);
+	      memcpy(buf, oa->oa_base, oa->oa_length);
 	      /* no real need....
 	         buf = (long *) ((char *) buf + RNDUP(oa->oa_length));
 	       */
@@ -138,7 +138,7 @@ xdr_callmsg (XDR *xdrs, struct rpc_msg *cmsg)
 		}
 	      else
 		{
-		  bcopy ((caddr_t) buf, oa->oa_base,
+		  memcpy(oa->oa_base, buf,
 			 oa->oa_length);
 		  /* no real need....
 		     buf = (long *) ((char *) buf
@@ -179,7 +179,7 @@ xdr_callmsg (XDR *xdrs, struct rpc_msg *cmsg)
 		}
 	      else
 		{
-		  bcopy ((caddr_t) buf, oa->oa_base,
+		  memcpy(oa->oa_base, buf,
 			 oa->oa_length);
 		  /* no real need...
 		     buf = (long *) ((char *) buf

--- a/sunrpc/rpc_main.c
+++ b/sunrpc/rpc_main.c
@@ -188,7 +188,6 @@ xdrfunc *xdrfunc_head = NULL;	/* xdr function list */
 xdrfunc *xdrfunc_tail = NULL;	/* xdr function list */
 
 int
-__attribute__ ((noreturn))
 main (int argc, const char *argv[])
 {
   struct commandline cmd;
@@ -258,6 +257,7 @@ main (int argc, const char *argv[])
     }
   exit (nonfatalerrors);
   /* NOTREACHED */
+  return nonfatalerrors;
 }
 
 /*

--- a/sunrpc/rpc_prot.c
+++ b/sunrpc/rpc_prot.c
@@ -212,7 +212,7 @@ static void
 rejected (enum reject_stat rjct_stat,
 	  struct rpc_err *error)
 {
-  switch (rjct_stat)
+  switch ((int)rjct_stat)
     {
     case RPC_VERSMISMATCH:
       error->re_status = RPC_VERSMISMATCH;

--- a/sunrpc/rpcinfo.c
+++ b/sunrpc/rpcinfo.c
@@ -551,7 +551,7 @@ pmapdump (argc, argv)
       memset((char *) &server_addr, 0, sizeof server_addr);
       server_addr.sin_family = AF_INET;
       if ((hp = gethostbyname ("localhost")) != NULL)
-	bcopy (hp->h_addr, (caddr_t) & server_addr.sin_addr,
+	memcpy(&server_addr.sin_addr, hp->h_addr,
 	       hp->h_length);
       else
 	server_addr.sin_addr.s_addr = inet_addr ("0.0.0.0");
@@ -742,7 +742,7 @@ get_inet_address (addr, host)
 		   host);
 	  exit (1);
 	}
-      bcopy (hp->h_addr, (char *) &addr->sin_addr, hp->h_length);
+      memcpy((char *) &addr->sin_addr, hp->h_addr, hp->h_length);
     }
   addr->sin_family = AF_INET;
 }

--- a/sunrpc/rpcinfo.c
+++ b/sunrpc/rpcinfo.c
@@ -548,7 +548,7 @@ pmapdump (argc, argv)
     get_inet_address (&server_addr, argv[0]);
   else
     {
-      bzero ((char *) &server_addr, sizeof server_addr);
+      memset((char *) &server_addr, 0, sizeof server_addr);
       server_addr.sin_family = AF_INET;
       if ((hp = gethostbyname ("localhost")) != NULL)
 	bcopy (hp->h_addr, (caddr_t) & server_addr.sin_addr,
@@ -731,7 +731,7 @@ get_inet_address (addr, host)
 {
   register struct hostent *hp;
 
-  bzero ((char *) addr, sizeof *addr);
+  memset((char *) addr, 0, sizeof *addr);
   addr->sin_addr.s_addr = (u_long) inet_addr (host);
   if (addr->sin_addr.s_addr == INADDR_NONE
       || addr->sin_addr.s_addr == INADDR_ANY)

--- a/sunrpc/rtime.c
+++ b/sunrpc/rtime.c
@@ -84,7 +84,7 @@ rtime (struct sockaddr_in *addrp, struct rpc_timeval *timep,
   int res;
   unsigned long thetime;
   struct sockaddr_in from;
-  int fromlen;
+  socklen_t fromlen;
   int type;
 
   if (timeout == NULL)

--- a/sunrpc/svc_authux.c
+++ b/sunrpc/svc_authux.c
@@ -80,7 +80,7 @@ _svcauth_unix (struct svc_req *rqst, struct rpc_msg *msg)
 	  stat = AUTH_BADCRED;
 	  goto done;
 	}
-      bcopy ((caddr_t) buf, aup->aup_machname, (u_int) str_len);
+      memcpy(aup->aup_machname, buf, str_len);
       aup->aup_machname[str_len] = 0;
       str_len = RNDUP (str_len);
       buf = (int32_t *) ((char *) buf + str_len);

--- a/sunrpc/svc_simple.c
+++ b/sunrpc/svc_simple.c
@@ -142,7 +142,7 @@ universal (struct svc_req *rqstp, SVCXPRT *transp)
     if (pl->p_prognum == prog && pl->p_procnum == proc)
       {
 	/* decode arguments into a CLEAN buffer */
-	__bzero (xdrbuf, sizeof (xdrbuf));	/* required ! */
+	memset(xdrbuf, 0, sizeof (xdrbuf));	/* required ! */
 	if (!svc_getargs (transp, pl->p_inproc, xdrbuf))
 	  {
 	    svcerr_decode (transp);

--- a/sunrpc/svc_tcp.c
+++ b/sunrpc/svc_tcp.c
@@ -160,7 +160,7 @@ svctcp_create (int sock, u_int sendsize, u_int recvsize)
 	}
       madesock = TRUE;
     }
-  __bzero ((char *) &addr, sizeof (addr));
+  memset((char *) &addr, 0, sizeof (addr));
   addr.sin_family = AF_INET;
   if (bindresvport (sock, &addr))
     {

--- a/sunrpc/svc_udp.c
+++ b/sunrpc/svc_udp.c
@@ -139,7 +139,7 @@ svcudp_bufcreate (sock, sendsz, recvsz)
 	}
       madesock = TRUE;
     }
-  __bzero ((char *) &addr, sizeof (addr));
+  memset((char *) &addr, 0, sizeof (addr));
   addr.sin_family = AF_INET;
   if (bindresvport (sock, &addr))
     {
@@ -397,7 +397,7 @@ svcudp_destroy (xprt)
 	(type *) mem_alloc((unsigned) (sizeof(type) * (size)))
 
 #define BZERO(addr, type, size)	 \
-	__bzero((char *) addr, sizeof(type) * (int) (size))
+	memset((char *) addr, 0, sizeof(type) * (int) (size))
 
 /*
  * An entry in the cache

--- a/sunrpc/svcauth_des.c
+++ b/sunrpc/svcauth_des.c
@@ -393,7 +393,7 @@ cache_init (void)
     mem_alloc (sizeof (struct cache_entry) * AUTHDES_CACHESZ);
   if (authdes_cache == NULL)
     return;
-  __bzero ((char *) authdes_cache,
+  memset((char *) authdes_cache, 0,
 	   sizeof (struct cache_entry) * AUTHDES_CACHESZ);
 
   authdes_lru = (int *) mem_alloc (sizeof (int) * AUTHDES_CACHESZ);

--- a/sunrpc/svcauth_des.c
+++ b/sunrpc/svcauth_des.c
@@ -145,7 +145,7 @@ _svcauth_des (register struct svc_req *rqst, register struct rpc_msg *msg)
 	  return AUTH_BADCRED;
 	}
       cred->adc_fullname.name = area->area_netname;
-      bcopy ((char *) ixdr, cred->adc_fullname.name, namelen);
+      memcpy(cred->adc_fullname.name, (char *) ixdr, namelen);
       cred->adc_fullname.name[namelen] = 0;
       ixdr += (RNDUP (namelen) / BYTES_PER_XDR_UNIT);
       cred->adc_fullname.key.key.high = *ixdr++;

--- a/sunrpc/xdr.c
+++ b/sunrpc/xdr.c
@@ -222,12 +222,12 @@ xdr_hyper (XDR *xdrs, quad_t *llp)
     {
       t1 = (long) ((*llp) >> 32);
       t2 = (long) (*llp);
-      return (XDR_PUTLONG(xdrs, &t1) && XDR_PUTLONG(xdrs, &t2));
+      return (XDR_PUTLONG(xdrs, &t1) && XDR_PUTLONG(xdrs, (long *)&t2));
     }
 
   if (xdrs->x_op == XDR_DECODE)
     {
-      if (!XDR_GETLONG(xdrs, &t1) || !XDR_GETLONG(xdrs, &t2))
+      if (!XDR_GETLONG(xdrs, &t1) || !XDR_GETLONG(xdrs, (long *)&t2))
 	return FALSE;
       *llp = ((quad_t) t1) << 32;
       *llp |= t2;
@@ -255,12 +255,12 @@ xdr_u_hyper (XDR *xdrs, u_quad_t *ullp)
     {
       t1 = (unsigned long) ((*ullp) >> 32);
       t2 = (unsigned long) (*ullp);
-      return (XDR_PUTLONG(xdrs, &t1) && XDR_PUTLONG(xdrs, &t2));
+      return (XDR_PUTLONG(xdrs, (long *)&t1) && XDR_PUTLONG(xdrs, (long *)&t2));
     }
 
   if (xdrs->x_op == XDR_DECODE)
     {
-      if (!XDR_GETLONG(xdrs, &t1) || !XDR_GETLONG(xdrs, &t2))
+      if (!XDR_GETLONG(xdrs, (long *)&t1) || !XDR_GETLONG(xdrs, (long *)&t2))
 	return FALSE;
       *ullp = ((u_quad_t) t1) << 32;
       *ullp |= t2;
@@ -325,10 +325,10 @@ xdr_u_short (XDR *xdrs, u_short *usp)
     {
     case XDR_ENCODE:
       l = (u_long) * usp;
-      return XDR_PUTLONG (xdrs, &l);
+      return XDR_PUTLONG (xdrs, (long *)&l);
 
     case XDR_DECODE:
-      if (!XDR_GETLONG (xdrs, &l))
+      if (!XDR_GETLONG (xdrs, (long *)&l))
 	{
 	  return FALSE;
 	}

--- a/sunrpc/xdr_array.c
+++ b/sunrpc/xdr_array.c
@@ -99,7 +99,7 @@ xdr_array (xdrs, addrp, sizep, maxsize, elsize, elproc)
 			    "xdr_array: out of memory\n");
 	    return FALSE;
 	  }
-	__bzero (target, nodesize);
+	memset(target, 0, nodesize);
 	break;
 
       case XDR_FREE:

--- a/sunrpc/xdr_intXX_t.c
+++ b/sunrpc/xdr_intXX_t.c
@@ -34,9 +34,9 @@ xdr_int64_t (XDR *xdrs, int64_t *ip)
     case XDR_ENCODE:
       t1 = (int32_t) ((*ip) >> 32);
       t2 = (int32_t) (*ip);
-      return (XDR_PUTINT32(xdrs, &t1) && XDR_PUTINT32(xdrs, &t2));
+      return (XDR_PUTINT32(xdrs, &t1) && XDR_PUTINT32(xdrs, (int32_t *)&t2));
     case XDR_DECODE:
-      if (!XDR_GETINT32(xdrs, &t1) || !XDR_GETINT32(xdrs, &t2))
+      if (!XDR_GETINT32(xdrs, &t1) || !XDR_GETINT32(xdrs, (int32_t *)&t2))
         return FALSE;
       *ip = ((int64_t) t1) << 32;
       *ip |= t2;

--- a/sunrpc/xdr_mem.c
+++ b/sunrpc/xdr_mem.c
@@ -132,7 +132,7 @@ xdrmem_getbytes (XDR *xdrs, caddr_t addr, u_int len)
 {
   if ((xdrs->x_handy -= len) < 0)
     return FALSE;
-  bcopy (xdrs->x_private, addr, len);
+  memcpy(addr, xdrs->x_private, len);
   xdrs->x_private += len;
   return TRUE;
 }
@@ -146,7 +146,7 @@ xdrmem_putbytes (XDR *xdrs, const char *addr, u_int len)
 {
   if ((xdrs->x_handy -= len) < 0)
     return FALSE;
-  bcopy (addr, xdrs->x_private, len);
+  memcpy(xdrs->x_private, addr, len);
   xdrs->x_private += len;
   return TRUE;
 }

--- a/sunrpc/xdr_rec.c
+++ b/sunrpc/xdr_rec.c
@@ -293,7 +293,7 @@ xdrrec_putbytes (XDR *xdrs, const char *addr, u_int len)
     {
       current = rstrm->out_boundry - rstrm->out_finger;
       current = (len < current) ? len : current;
-      bcopy (addr, rstrm->out_finger, current);
+      memcpy(rstrm->out_finger, addr, current);
       rstrm->out_finger += current;
       addr += current;
       len -= current;
@@ -595,7 +595,7 @@ get_input_bytes (RECSTREAM *rstrm, caddr_t addr, int len)
 	  continue;
 	}
       current = (len < current) ? len : current;
-      bcopy (rstrm->in_finger, addr, current);
+      memcpy(addr, rstrm->in_finger, current);
       rstrm->in_finger += current;
       addr += current;
       len -= current;

--- a/sunrpc/xdr_ref.c
+++ b/sunrpc/xdr_ref.c
@@ -92,7 +92,7 @@ xdr_reference (xdrs, pp, size, proc)
 	    (void) fputs (_("xdr_reference: out of memory\n"), stderr);
 	    return FALSE;
 	  }
-	__bzero (loc, (int) size);
+	memset(loc, 0, size);
 	break;
       default:
 	break;

--- a/syscall/pars.y
+++ b/syscall/pars.y
@@ -151,13 +151,13 @@ gemdos
 		systab = malloc(sizeof(*systab));
 		OUT_OF_MEM(systab);
 
-		bzero(systab, sizeof(*systab));
+		memset(systab, 0, sizeof(*systab));
 
 		systab->size = INITIAL_GEMDOS;
 		systab->table = malloc(systab->size * sizeof(*(systab->table)));
 		OUT_OF_MEM(systab->table);
 
-		bzero(systab->table, systab->size * sizeof(*(systab->table)));
+		memset(systab->table, 0, systab->size * sizeof(*(systab->table)));
 	}
 	'[' _IDENT_GEMDOS ']' definition_list
 	{
@@ -170,13 +170,13 @@ bios
 		systab = malloc(sizeof(*systab));
 		OUT_OF_MEM(systab);
 
-		bzero(systab, sizeof(*systab));
+		memset(systab, 0, sizeof(*systab));
 
 		systab->size = INITIAL_BIOS;
 		systab->table = malloc(systab->size * sizeof(*(systab->table)));
 		OUT_OF_MEM(systab->table);
 
-		bzero(systab->table, systab->size * sizeof(*(systab->table)));
+		memset(systab->table, 0, systab->size * sizeof(*(systab->table)));
 	}
 	'[' _IDENT_BIOS ']' definition_list
 	{
@@ -189,13 +189,13 @@ xbios
 		systab = malloc(sizeof(*systab));
 		OUT_OF_MEM(systab);
 
-		bzero(systab, sizeof(*systab));
+		memset(systab, 0, sizeof(*systab));
 
 		systab->size = INITIAL_XBIOS;
 		systab->table = malloc(systab->size * sizeof(*(systab->table)));
 		OUT_OF_MEM(systab->table);
 
-		bzero(systab->table, systab->size * sizeof(*(systab->table)));
+		memset(systab->table, 0, systab->size * sizeof(*(systab->table)));
 	}
 	'[' _IDENT_XBIOS ']' definition_list
 	{
@@ -539,7 +539,7 @@ resize_tab(struct systab *tab, int newsize)
 
 		if (newtable)
 		{
-			bzero(newtable, newsize * sizeof(*newtable));
+			memset(newtable, 0, newsize * sizeof(*newtable));
 			memcpy(newtable, tab->table, tab->size * sizeof(*(tab->table)));
 
 			free(tab->table);
@@ -574,7 +574,7 @@ add_tab(struct systab *tab, int nr, const char *name, struct arg *r, struct arg 
 		if (!call)
 			return 1;
 
-		bzero(call, sizeof(*call));
+		memset(call, 0, sizeof(*call));
 
 		strcpy(call->name, name);
 		call->ret = r;
@@ -607,7 +607,7 @@ make_arg(int type, const char *s)
 
 	if (l)
 	{
-		bzero(l, sizeof(*l));
+		memset(l, 0, sizeof(*l));
 
 		if (s) strcpy(l->types, s);
 		l->type = type;

--- a/syscall/scan.l
+++ b/syscall/scan.l
@@ -37,7 +37,15 @@
 int yylex (void);
 int yylinecount = 1;
 
+#define YY_INPUT(buf,result,max_size) \
+		result = (int) fread(buf, 1, max_size, yyin)
+
 %}
+
+%option nounput
+%option noinput
+%option nointeractive never-interactive
+%option noyywrap
 
 digit		[0-9]
 nonzerodigit	[1-9]

--- a/time/strptime.c
+++ b/time/strptime.c
@@ -249,7 +249,9 @@ strptime_internal (rp, fmt, tm, decided, era_cnt)
      enum locale_status *decided;
      int era_cnt;
 {
+#ifdef _NL_CURRENT
   const char *rp_backup;
+#endif
   int cnt;
   size_t val;
   int have_I, is_pm;
@@ -304,7 +306,9 @@ strptime_internal (rp, fmt, tm, decided, era_cnt)
 #endif
 
       /* Make back up of current processing pointer.  */
+#ifdef _NL_CURRENT
       rp_backup = rp;
+#endif
 
       switch (*fmt++)
 	{
@@ -980,7 +984,8 @@ strptime_internal (rp, fmt, tm, decided, era_cnt)
 	  tm->tm_year += 100;
       }
 #endif
-
+  (void) want_era;
+  
   if (want_xday && !have_wday)
     {
       if ( !(have_mon && have_mday) && have_yday)

--- a/tz/date.c
+++ b/tz/date.c
@@ -849,7 +849,7 @@ netsettime(ntv)
 			perror("date: socket");
 		goto bad;
 	}
-	bzero((char *)&sin, sizeof (sin));
+	memset((char *)&sin, 0, sizeof (sin));
 	sin.sin_family = AF_INET;
 	for (port = IPPORT_RESERVED - 1; port > IPPORT_RESERVED / 2; port--) {
 		sin.sin_port = htons((u_short)port);

--- a/tz/strftime.c
+++ b/tz/strftime.c
@@ -29,13 +29,17 @@ static char	elsieid[] = "@(#)strftime.c	8.3";
 
 #ifndef LIBC_SCCS
 #ifndef lint
-static const char	sccsid[] = "@(#)strftime.c	5.4 (Berkeley) 3/14/89";
+/* static const char	sccsid[] = "@(#)strftime.c	5.4 (Berkeley) 3/14/89"; */
 #endif /* !defined lint */
 #endif /* !defined LIBC_SCCS */
 
 #include "tzfile.h"
 #include "fcntl.h"
 #include "locale.h"
+
+#if __GNUC_PREREQ(7, 0)
+# pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
 
 struct lc_time_T {
 	const char *	mon[MONSPERYEAR];

--- a/unix/getrusage.c
+++ b/unix/getrusage.c
@@ -40,7 +40,7 @@ __getrusage(enum __rusage_who which, struct rusage *data)
 	long r;
 	long usage[8];
 
-	_bzero(data, (unsigned long) (sizeof (struct rusage)));
+	memset(data, 0, sizeof(*data));
 	
 	r = Prusage(usage);
 

--- a/unix/lseek.c
+++ b/unix/lseek.c
@@ -57,7 +57,7 @@ __lseek (int handle, off_t offset, int mode)
 	new_pos = Fseek (0L, handle, SEEK_END);	/* go to eof */
     }	
     
-    __bzero (buf, (size_t)256);
+    memset(buf, 0, sizeof(buf));
     while (expected_pos > new_pos)	
     {
 	offset = expected_pos - new_pos;

--- a/unix/poll.c
+++ b/unix/poll.c
@@ -38,7 +38,6 @@ __poll (struct pollfd *fds, unsigned long int nfds, __int32_t __timeout)
 		unsigned long xfds = 0;
 		register unsigned long int i;
 		register struct pollfd* pfds = fds;
-		unsigned long early_out = 0;
 
 		for (i = 0; i < nfds; i++) {
 			pfds[i].revents = 0;

--- a/unix/select.c
+++ b/unix/select.c
@@ -52,7 +52,7 @@ __select (int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 	}
 	
 	pfds = alloca (nfds * sizeof *pfds);
-	__bzero (pfds, nfds * sizeof *pfds);
+	memset(pfds, 0, nfds * sizeof *pfds);
 	
 	/* Three loops are more efficient than one here.  */
 	if (readfds != NULL)
@@ -90,9 +90,9 @@ __select (int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 	else {
 		u_int sz = howmany (nfds, NFDBITS) * sizeof (fd_mask);
 		
-		if (readfds) __bzero (readfds, sz);
-		if (exceptfds) __bzero (exceptfds, sz);
-		if (writefds) __bzero (writefds, sz);
+		if (readfds) memset(readfds, 0, sz);
+		if (exceptfds) memset(exceptfds, 0, sz);
+		if (writefds) memset(writefds, 0, sz);
 		
 		if (retval) for (i = 0; i < nfds; i++) {
 			if (pfds[i].revents & POLLIN

--- a/unix/sysinfo.c
+++ b/unix/sysinfo.c
@@ -213,7 +213,6 @@ si_release (buf, bufsize)
   static char* osrelease = NULL;
   static char osrelease_buf[13];
   static long osrelease_len;
-  static long mintversion;
 
   if (osrelease == NULL) {
     unsigned long main_rev = 0;
@@ -262,8 +261,6 @@ si_release (buf, bufsize)
       sprintf (osrelease_buf, "%lu.%lu%s", main_rev, sub_rev, betatag);
     osrelease = osrelease_buf;
     osrelease_len = strlen (osrelease) + 1;
-    mintversion = (main_rev << 24) | (sub_rev << 16)
-        | (patch_level << 8) | betatag[0];
   }
 
   fast_strncpy (buf, osrelease, bufsize);
@@ -519,7 +516,7 @@ si_platform (buf, bufsize)
 {
   if (platform == NULL) {
     long _mch = 0;  /* = AtariST */
-    short hi, lo;
+    short hi;
     int coldfire = 0;
     long dummy;
 
@@ -534,7 +531,7 @@ si_platform (buf, bufsize)
 
       (void) Getcookie (C__MCH, &_mch);
       hi = (_mch & 0xffff0000) >> 16;
-      lo = (_mch & 0xffff);
+      /* lo = (_mch & 0xffff); */
 
       switch (hi) {
         case -1:
@@ -603,7 +600,7 @@ si_hw_provider (buf, bufsize)
 /* Cached results.  */
 static int no_build_date = 0;
 static char* kernel_build_date = NULL;
-static char kernel_build_date_buf[] = "Mmm DD YYYY";
+static char kernel_build_date_buf[14];
 #define kernel_build_date_len ((long) sizeof kernel_build_date_buf)
 
 static char* abbrev_month_names[] = {

--- a/unix/test-fdset.c
+++ b/unix/test-fdset.c
@@ -27,7 +27,7 @@ main (int argc, char* argv[])
 	int status = 0;
 	int prime = 2;
 	
-	bzero (sieve, FD_SETSIZE);
+	memset(sieve, 0, FD_SETSIZE);
 	sieve[0] = 1;
 	sieve[1] = 1;
 	

--- a/unix/utime.c
+++ b/unix/utime.c
@@ -48,12 +48,12 @@ __utime (const char *_filename, const struct utimbuf *_tset)
 	/* The FUTIME_UTC failed.  We have to convert the timestamp
 	   to GEMDOS format.  */   
 	if (_tset) {
-		*((unsigned long*) &(settime.modtime)) = 
-			__dostime (_tset->modtime);
-		*((unsigned long*) &(settime.actime)) = 
-			__dostime (_tset->actime);
+		unsigned long *tp = (unsigned long*) &(settime.modtime);
+		*tp =  __dostime (_tset->modtime);
+		tp = (unsigned long*) &(settime.actime);
+		*tp = __dostime (_tset->actime);
 		
-			tset = &settime;
+		tset = &settime;
 	}
 
 	/* Try again with FUTIME.  */


### PR DESCRIPTION
- Avoid optimization of malloc/memset to calloc in its own implementation
- Allow prefix for cross-tools to be overridden
- Fix for parallel makes
- Replace calls to deprecated bzero by memset
- Replace calls to deprecated bcopy by memcpy
- Move malloc-related definitions to separate file
- Fix long double math functions for coldfire
- Explicitly add -fno-omit-frame-pointer for sources that need it