### PR TITLE
Exclude some include files from include-fixed directory

### DIFF
--- a/include/gnu-out.h
+++ b/include/gnu-out.h
@@ -117,7 +117,7 @@ enum machine_type {
 /* Address of data segment in memory after it is loaded.
    Note that it is up to you to define SEGMENT_SIZE
    on machines not listed here.  */
-#if defined(atarist) || defined(CROSSATARI) || defined(atariminix) || defined(MINIX)
+#if defined(__atarist__) || defined(CROSSATARI) || defined(atariminix) || defined(MINIX)
 #  ifdef vax
 #    undef vax
 #  endif
@@ -151,7 +151,7 @@ enum machine_type {
 #define PAGE_SIZE 0x400
 #define SEGMENT_SIZE PAGE_SIZE
 #endif
-#if defined(atarist) || defined(CROSSATARI) || defined(atariminix) || defined(MINIX)
+#if defined(__atarist__) || defined(CROSSATARI) || defined(atariminix) || defined(MINIX)
 #define SEGMENT_SIZE 2
 #endif
 

--- a/include/math.h
+++ b/include/math.h
@@ -75,7 +75,12 @@ typedef enum  {
     PLOSS       = 6
 } exception_type;
 
-/* In C++ exception is a reserved word.  */
+/* In SVID error handling, `matherr' is called with this description
+   of the exceptional condition.
+
+   We have a problem when using C++ since `exception' is a reserved
+   name in C++.  */
+/* do not change the comment above; it is looked up by GCCs fixincludes script */
 #ifdef __cplusplus
 struct __exception
 #else

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -201,7 +201,7 @@ extern void *__calloc (size_t __n, size_t __s) __THROW;
 
 #ifndef __STRICT_ANSI__
 
-# ifdef atarist
+# ifdef __atarist__
 extern void _malloczero (int __yes) __THROW;
 extern void _mallocChunkSize (size_t __siz) __THROW;
 # endif

--- a/include/sys/syslog.h
+++ b/include/sys/syslog.h
@@ -188,7 +188,7 @@ CODE facilitynames[] =
    emulate one.  */
 #define __need___va_list
 #include <stdarg.h>
-#define _BSD_VA_LIST_ __gnuc_va_list
+#define _BSD_VA_LIST_ __builtin_va_list
 #endif
 
 #include <sys/cdefs.h>


### PR DESCRIPTION
Fix some include files to prevent them from ending up in the include-fixed directory when compiling gcc.

There are still some files ending up there:
- bits/string2.h, due to the definition of strncpy (gcc wants it to be defined just as __builtin_strncpy)
- math.h, due to the definition of exception for c++, although it is protected and uses the same mechanism as seen in recent glibc header
- sys/syslog.h, due to the definition of __BSD_VA_LIST

The output from the fixincludes run is:
Fixing directory /usr/m68k-atari-mint/sys-root/usr/include into /home/sebilla/mintstd/mint7-build/gcc/include-fixed
Applying glibc_c99_inline_3       to bits/string2.h
Applying glibc_strncpy            to bits/string2.h
Fixed:  bits/string2.h
Applying machine_ansi_h_va_list   to sys/syslog.h
Fixed:  sys/syslog.h
Applying glibc_stdint             to stdint.h
Applying sysv68_string            to string.h
Applying sun_malloc               to malloc.h
Applying math_exception           to math.h
Fixed:  math.h
Cleaning up unneeded directories:
fixincludes is done

The patterns that are searched for are defined in ../gcc-src/fixincludes/inclhack.def

