### PR TITLE
Clean up assembler code to use % prefix for register names

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -145,6 +145,19 @@
 # endif
 #endif
 
+#ifndef __USER_LABEL_PREFIX__
+#  if defined(__ELF__)
+#    define __USER_LABEL_PREFIX__
+#  else
+#    define __USER_LABEL_PREFIX__ _
+#  endif
+#endif
+
+#ifndef __SYMBOL_PREFIX
+# define __SYMBOL_PREFIX __STRINGIFY(__USER_LABEL_PREFIX__)
+# define __ASM_SYMBOL_PREFIX __USER_LABEL_PREFIX__
+#endif
+
 #ifndef _LINKER_H
 # include <linker.h>
 #endif

--- a/include/mint/falcon.h
+++ b/include/mint/falcon.h
@@ -24,17 +24,17 @@ __extension__								\
 									\
 	__asm__ volatile						\
 	(								\
-		"movw	%6,sp@-\n\t"					\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%6,%%sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(12),sp"					\
+		"lea	%%sp@(12),%%sp"					\
 	: "=r"(retvalue)						\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d), "r"(_e)		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory");		\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory");		\
 	retvalue;							\
 })
 #endif
@@ -51,16 +51,16 @@ __extension__								\
 									\
 	__asm__ volatile						\
 	(								\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(18),sp"					\
+		"lea	%%sp@(18),%%sp"					\
 	: "=r"(retvalue)						\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d)			\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory");		\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory");		\
 	retvalue;							\
 })
 #endif
@@ -79,18 +79,18 @@ __extension__								\
 									\
 	__asm__ volatile						\
 	(								\
-		"movl	%7,sp@-\n\t"					\
-		"movl	%6,sp@-\n\t"					\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%7,%%sp@-\n\t"					\
+		"movl	%6,%%sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(26),sp"					\
+		"lea	%%sp@(26),%%sp"					\
 	: "=r"(retvalue)						\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d), "r"(_e), "r"(_f)	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory");		\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory");		\
 	retvalue;							\
 })
 #endif
@@ -105,14 +105,14 @@ __extension__								\
 									\
 	__asm__ volatile						\
 	(								\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(10),sp"					\
+		"lea	%%sp@(10),%%sp"					\
 	: "=r"(retvalue)						\
 	: "g"(n), "r"(_a), "r"(_b)					\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory");		\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory");		\
 	retvalue;							\
 })
 #endif
@@ -128,15 +128,15 @@ __extension__								\
 									\
 	__asm__ volatile						\
 	(								\
-		"movl	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(12),sp"					\
+		"lea	%%sp@(12),%%sp"					\
 	: "=r"(retvalue)						\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)				\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory");		\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory");		\
 	retvalue;							\
 })
 #endif

--- a/include/mint/metados.h
+++ b/include/mint/metados.h
@@ -24,7 +24,7 @@
 #include <mint/falcon.h>	/* for trap_14_xxx macros */
 
 #ifndef OSBIND_CLOBBER_LIST
-#define OSBIND_CLOBBER_LIST	"d1", "d2", "a0", "a1", "a2", "memory"
+#define OSBIND_CLOBBER_LIST	"d1", "d2", "a0", "a1", "a2", "cc", "memory"
 #endif
 
 #ifndef trap_14_wwlwl
@@ -38,13 +38,13 @@ __extension__	\
 	long _d = (long)(d);	\
 	\
 	__asm__ volatile (	\
-		"movl	%5,sp@-\n\t"	\
-		"movw	%4,sp@-\n\t"	\
-		"movl	%3,sp@-\n\t"	\
-		"movw	%2,sp@-\n\t"	\
-		"movw	%1,sp@-\n\t"	\
+		"movl	%5,%%sp@-\n\t"	\
+		"movw	%4,%%sp@-\n\t"	\
+		"movl	%3,%%sp@-\n\t"	\
+		"movw	%2,%%sp@-\n\t"	\
+		"movw	%1,%%sp@-\n\t"	\
 		"trap	#14\n\t"	\
-		"lea	sp@(14),sp"	\
+		"lea	%%sp@(14),%%sp"	\
 		: "=r"(retvalue)	\
 		: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d)	\
 		: OSBIND_CLOBBER_LIST	\
@@ -64,13 +64,13 @@ __extension__	\
 	long _d = (long)(d);	\
 	\
 	__asm__ volatile (	\
-		"movl	%5,sp@-\n\t"	\
-		"movl	%4,sp@-\n\t"	\
-		"movw	%3,sp@-\n\t"	\
-		"movw	%2,sp@-\n\t"	\
-		"movw	%1,sp@-\n\t"	\
+		"movl	%5,%%sp@-\n\t"	\
+		"movl	%4,%%sp@-\n\t"	\
+		"movw	%3,%%sp@-\n\t"	\
+		"movw	%2,%%sp@-\n\t"	\
+		"movw	%1,%%sp@-\n\t"	\
 		"trap	#14\n\t"	\
-		"lea	sp@(14),sp"	\
+		"lea	%%sp@(14),%%sp"	\
 		: "=r"(retvalue)	\
 		: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d)	\
 		: OSBIND_CLOBBER_LIST	\

--- a/include/mint/mintbind.h
+++ b/include/mint/mintbind.h
@@ -24,15 +24,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(12),sp"					\
+		"lea	%%sp@(12),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -48,15 +48,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(10),sp"					\
+		"lea	%%sp@(10),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -72,15 +72,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"addql	#8,sp"						\
+		"addql	#8,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -96,15 +96,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(10),sp"					\
+		"lea	%%sp@(10),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -119,14 +119,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"addql	#8,sp"						\
+		"addql	#8,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -143,16 +143,16 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(16),sp"					\
+		"lea	%%sp@(16),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d) /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -168,15 +168,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(14),sp"					\
+		"lea	%%sp@(14),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)	/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 									\
@@ -195,17 +195,17 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%6,sp@-\n\t"					\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%6,%%sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(20),sp "					\
+		"lea	%%sp@(20),%%sp "					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d), "r"(_e) /* inputs  */ \
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -222,17 +222,17 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(18),sp"					\
+		"lea	%%sp@(18),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c),				\
 	  "r"(_d)				/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 									\
@@ -252,19 +252,19 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%7,sp@-\n\t"					\
-		"movl	%6,sp@-\n\t"					\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%7,%%sp@-\n\t"					\
+		"movl	%6,%%sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(24),sp"					\
+		"lea	%%sp@(24),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c),				\
 	  "r"(_d), "r"(_e), "r"(_f)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 									\
@@ -283,18 +283,18 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%6,sp@-\n\t"					\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%6,%%sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(22),sp"					\
+		"lea	%%sp@(22),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c),				\
 	  "r"(_d), "r"(_e)			/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 									\
@@ -314,19 +314,19 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%7,sp@-\n\t"					\
-		"movl	%6,sp@-\n\t"					\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%7,%%sp@-\n\t"					\
+		"movl	%6,%%sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(26),sp"					\
+		"lea	%%sp@(26),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c),				\
 	  "r"(_d), "r"(_e), "r"(_f)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 									\
@@ -479,7 +479,7 @@ __extension__								\
 		trap_1_wwwll(0x140, (short)(request), (short)(pid), \
 			      (long)(addr), (long)(data))
 #define Mvalidate(pid,addr,size,flags)				\
-		trap_1_wwlll (0x141, (short)(pid), (long)(addr), (long)(size), (long)(flags))
+		trap_1_wwlll(0x141, (short)(pid), (long)(addr), (long)(size), (long)(flags))
 #define Dxreaddir(len, handle, buf, xattr, xret)		\
 		trap_1_wwllll(0x142, (short)(len), (long)(handle), \
 			      (long)(buf), (long)(xattr), (long)(xret))
@@ -521,7 +521,7 @@ __extension__								\
 #define Dwritelabel(path, label)  \
 		trap_1_wll(0x153, (long)(path), (long)(label))
 #define Ssystem(mode, arg1, arg2) \
-		trap_1_wwll(0x154, (int)(mode), (long)(arg1), (long)(arg2))
+		trap_1_wwll(0x154, (short)(mode), (long)(arg1), (long)(arg2))
 #define Tgettimeofday(tvp, tzp) \
 		trap_1_wll(0x155, (long)(tvp), (long)(tzp))
 #define Tsettimeofday(tvp, tzp) \
@@ -601,7 +601,7 @@ __extension__								\
 		trap_1_wlllll(0x17b,(long)(msqid),(long)(msgp),(long)(msgsz),(long)(msgtyp),(long)(msgflg))
 /* 0x17c */
 #define Maccess(addr,size,mode) \
-		trap_1_wllw (0x17d, (long)(addr), (long)(size), (short)(mode))
+		trap_1_wllw(0x17d, (long)(addr), (long)(size), (short)(mode))
 /* 0x17e */
 /* 0x17f */
 #define Fchown16(name, uid, gid, follow_links) \

--- a/include/mint/osbind.h
+++ b/include/mint/osbind.h
@@ -131,12 +131,12 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"addql	#2,sp\n\t"					\
+		"addql	#2,%%sp\n\t"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n)				/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -150,13 +150,13 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"addql	#4,sp"						\
+		"addql	#4,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a)			/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -170,13 +170,13 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"addql	#6,sp"						\
+		"addql	#6,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a)			/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -191,14 +191,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"addql	#8,sp"						\
+		"addql	#8,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -214,15 +214,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(12),sp"					\
+		"lea	%%sp@(12),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -238,15 +238,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(10),sp"					\
+		"lea	%%sp@(10),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -263,16 +263,16 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(12),sp"					\
+		"lea	%%sp@(12),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d) /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -286,14 +286,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"addql	#6,sp"						\
+		"addql	#6,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -308,14 +308,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(10),sp"					\
+		"lea	%%sp@(10),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -332,16 +332,16 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(16),sp"					\
+		"lea	%%sp@(16),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d) /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -357,16 +357,16 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"lea	sp@(14),sp"					\
+		"lea	%%sp@(14),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c), "r"(_d) /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -379,13 +379,13 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#13\n\t"					\
-		"addql	#6,sp"						\
+		"addql	#6,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a)			/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -398,12 +398,12 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#13\n\t"					\
-		"addql	#2,sp"						\
+		"addql	#2,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n)				/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -417,13 +417,13 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#13\n\t"					\
-		"addql	#4,sp"						\
+		"addql	#4,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a)			/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -438,14 +438,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#13\n\t"					\
-		"addql	#6,sp"						\
+		"addql	#6,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -463,18 +463,18 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%6,sp@-\n\t"					\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%6,%%sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#13\n\t"					\
-		"lea	sp@(14),sp"					\
+		"lea	%%sp@(14),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n),							\
 	  "r"(_a), "r"(_b), "r"(_c), "r"(_d), "r"(_e) /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -488,14 +488,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#13\n\t"					\
-		"addql	#8,sp"						\
+		"addql	#8,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -510,14 +510,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"addql	#8,sp"						\
+		"addql	#8,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)              /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -533,15 +533,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(12),sp"					\
+		"lea	%%sp@(12),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -555,13 +555,13 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"addql	#4,sp"						\
+		"addql	#4,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a)			/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -574,12 +574,12 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"addql	#2,sp"						\
+		"addql	#2,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n)				/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -595,15 +595,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(12),sp"					\
+		"lea	%%sp@(12),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)       /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -617,13 +617,13 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"addql	#6,sp"						\
+		"addql	#6,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a)			/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -638,14 +638,14 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"addql	#6,sp"						\
+		"addql	#6,%%sp"						\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b)		/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -665,20 +665,20 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%8,sp@-\n\t"					\
-		"movw	%7,sp@-\n\t"					\
-		"movw	%6,sp@-\n\t"					\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%8,%%sp@-\n\t"					\
+		"movw	%7,%%sp@-\n\t"					\
+		"movw	%6,%%sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(20),sp "					\
+		"lea	%%sp@(20),%%sp "					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b),					\
 	  "r"(_c), "r"(_d), "r"(_e), "r"(_f), "r"(_g) /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -698,21 +698,21 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%9,sp@-\n\t"					\
-		"movl	%8,sp@-\n\t"					\
-		"movw	%7,sp@-\n\t"					\
-		"movw	%6,sp@-\n\t"					\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%9,%%sp@-\n\t"					\
+		"movl	%8,%%sp@-\n\t"					\
+		"movw	%7,%%sp@-\n\t"					\
+		"movw	%6,%%sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(24),sp "					\
+		"lea	%%sp@(24),%%sp "					\
 	: "=r"(retvalue)			   /* outputs */	\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c),				\
 	  "r"(_d), "r"(_e), "r"(_f), "r"(_g), "r"(_h) /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -733,16 +733,16 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%9,sp@-\n\t"					\
-		"movl	%8,sp@-\n\t"					\
-		"movw	%7,sp@-\n\t"					\
-		"movw	%6,sp@-\n\t"					\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movl	%1,sp@-\n\t"					\
-                "movw	%0,sp@-"					\
+		"movw	%9,%%sp@-\n\t"					\
+		"movl	%8,%%sp@-\n\t"					\
+		"movw	%7,%%sp@-\n\t"					\
+		"movw	%6,%%sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movl	%1,%%sp@-\n\t"					\
+                "movw	%0,%%sp@-"					\
 	:					      /* outputs */	\
 	: "g"(n), "g"(_a), "g"(_b), "g"(_c), "g"(_d),			\
 	  "g"(_e), "g"(_f), "g"(_g), "g"(_h), "g"(_i) /* inputs  */	\
@@ -751,10 +751,10 @@ __extension__								\
 	__asm__ volatile						\
 	(								\
 		"trap	#14\n\t"					\
-		"lea	sp@(26),sp"					\
+		"lea	%%sp@(26),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: 					/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -773,19 +773,19 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%7,sp@-\n\t"					\
-		"movw	%6,sp@-\n\t"					\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%7,%%sp@-\n\t"					\
+		"movw	%6,%%sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(14),sp"					\
+		"lea	%%sp@(14),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "g"(_a),						\
 	  "g"(_b), "g"(_c), "g"(_d), "g"(_e), "g"(_f)	/* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -800,15 +800,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(14),sp "					\
+		"lea	%%sp@(14),%%sp "					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)     /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -825,17 +825,17 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movl	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movl	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(14),sp"					\
+		"lea	%%sp@(14),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n),							\
 	  "r"(_a), "r"(_b), "r"(_c), "r"(_d)    /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -851,17 +851,17 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%5,sp@-\n\t"					\
-		"movw	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%5,%%sp@-\n\t"					\
+		"movw	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(12),sp "					\
+		"lea	%%sp@(12),%%sp "					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n),							\
 	  "r"(_a), "r"(_b), "r"(_c), "r"(_d)        /* inputs  */	\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
 	);								\
 	retvalue;							\
 })
@@ -876,15 +876,15 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movl	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movw	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movw	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(10),sp"					\
+		"lea	%%sp@(10),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n), "r"(_a), "r"(_b), "r"(_c)	/* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"    /* clobbered regs */	\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"    /* clobbered regs */	\
 	  AND_MEMORY							\
 	);								\
 	retvalue;							\
@@ -901,17 +901,18 @@ __extension__								\
 	    								\
 	__asm__ volatile						\
 	(								\
-		"movw	%5,sp@-\n\t"					\
-		"movl	%4,sp@-\n\t"					\
-		"movw	%3,sp@-\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	%1,sp@-\n\t"					\
+		"movw	%5,%%sp@-\n\t"					\
+		"movl	%4,%%sp@-\n\t"					\
+		"movw	%3,%%sp@-\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	%1,%%sp@-\n\t"					\
 		"trap	#14\n\t"					\
-		"lea	sp@(14),sp"					\
+		"lea	%%sp@(14),%%sp"					\
 	: "=r"(retvalue)			/* outputs */		\
 	: "g"(n),							\
 	  "r"(_a), "r"(_b), "r"(_c), "r"(_d)    /* inputs  */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "memory"			\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc", "memory"			\
+	  AND_MEMORY							\
 	);								\
 	retvalue;							\
 })
@@ -1001,14 +1002,15 @@ __extension__								\
 									\
 	__asm__ volatile						\
 	(								\
-		"movl	sp,%1\n\t"					\
-		"movl	%2,sp@-\n\t"					\
-		"movw	#0x20,sp@-\n\t"					\
+		"movl	%%sp,%1\n\t"					\
+		"movl	%2,%%sp@-\n\t"					\
+		"movw	#0x20,%%sp@-\n\t"					\
 		"trap	#1\n\t"						\
-		"movl	%1,sp\n\t"					\
+		"movl	%1,%%sp\n\t"					\
 	: "=r"(retvalue), "=&r"(sp_backup)	/* outputs */		\
 	: "g"((long)(ptr)) 			/* inputs */		\
-	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2"		\
+	: __CLOBBER_RETURN("d0") "d1", "d2", "a0", "a1", "a2", "cc"		\
+	  AND_MEMORY							\
 	);								\
 })
 

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -93,6 +93,7 @@
 
 #define __CONCAT(x,y)	x ## y
 #define __STRING(x)	#x
+#define __STRINGIFY(x)	__STRING(x)
 
 /* This is not a typedef so `const __ptr_t' does the right thing.  */
 #define __ptr_t void *

--- a/mintlib/_infinitydf.S
+++ b/mintlib/_infinitydf.S
@@ -1,6 +1,9 @@
+#include "libc-symbols.h"
+
 	.text
 	.even
-	.globl	__infinitydf
 
-__infinitydf:			| +infinity as proposed by IEEE
+	.globl	C_SYMBOL_NAME(_infinitydf)
+
+C_SYMBOL_NAME(_infinitydf):			| +infinity as proposed by IEEE
 	.long	0x7ff00000,0x00000000

--- a/mintlib/_mon.S
+++ b/mintlib/_mon.S
@@ -11,12 +11,15 @@
 | Dummy interfaces for gprof if not linked against (g)crt0.o.
 
 #ifndef PROFILING
-	.globl 	__monstartup
-	.globl	__moncontrol
-	.globl 	___mcleanup
 
-__monstartup:
-__moncontrol:
-___mcleanup:
+#include "libc-symbols.h"
+
+	.globl 	C_SYMBOL_NAME(_monstartup)
+	.globl	C_SYMBOL_NAME(_moncontrol)
+	.globl 	C_SYMBOL_NAME(__mcleanup)
+
+C_SYMBOL_NAME(_monstartup):
+C_SYMBOL_NAME(_moncontrol):
+C_SYMBOL_NAME(__mcleanup):
 	rts
 #endif

--- a/mintlib/_normdf.S
+++ b/mintlib/_normdf.S
@@ -49,13 +49,15 @@
 | Revision 1.0:
 | original 8088 code from P.S.Housel
 
+#include "libc-symbols.h"
+
 	.text
 	.even
-	.globl	__infinitydf
+	.globl	C_SYMBOL_NAME(_infinitydf)
 
 #if !defined (__M68881__) && !defined (sfp004)
-	.globl	___normdf
-	.globl	___norm_df
+	.globl	C_SYMBOL_NAME(__normdf)
+	.globl	C_SYMBOL_NAME(__norm_df)
 #include "errbase.h"
 # ifdef	ERROR_CHECK
 LC0:
@@ -65,250 +67,250 @@ LC0:
 
 	| C entry, for procs dealing with the internal representation :
 	| double __normdf(long long mant, int exp, int sign, int rbits);
-___normdf:
-	lea	sp@(4),a0	| parameter pointer
+C_SYMBOL_NAME(__normdf):
+	lea	%sp@(4),%a0	| parameter pointer
 #ifdef __mcoldfire__
-	lea	sp@(-24),sp
-	moveml	d2-d7,sp@	| save working registers
-	movel	a0@+,d4		| get mantissa
-	movel	a0@+,d5
+	lea	%sp@(-24),%sp
+	moveml	%d2-%d7,%sp@	| save working registers
+	movel	%a0@+,%d4		| get mantissa
+	movel	%a0@+,%d5
 #else
-	moveml	d2-d7,sp@-	| save working registers
-	moveml	a0@+,d4-d5	| get mantissa
+	moveml	%d2-%d7,%sp@-	| save working registers
+	moveml	%a0@+,%d4-%d5	| get mantissa
 #endif
 
 # ifdef __MSHORT__
-	movew	a0@+,d0		| get exponent
-	movew	a0@+,d2		| get sign
-	movew	a0@+,d1		| rounding information
+	movew	%a0@+,%d0		| get exponent
+	movew	%a0@+,%d2		| get sign
+	movew	%a0@+,%d1		| rounding information
 # else
-	movel	a0@+,d0		| get exponent
-	movel	a0@+,d2		| get sign
+	movel	%a0@+,%d0		| get exponent
+	movel	%a0@+,%d2		| get sign
 	jpl	0f		| or bit 31 to bit 15 for later tests
-	bset	#15,d2
-0:	movel	a0@+,d1		| rounding information
+	bset	#15,%d2
+0:	movel	%a0@+,%d1		| rounding information
 
-	movel	#0x7fff,d3
-	cmpl	d3,d0		| test exponent
+	movel	#0x7fff,%d3
+	cmpl	%d3,%d0		| test exponent
 	jgt	oflow
-	notl	d3		| #-0x8000 -> d3
-	cmpl	d3,d0
+	notl	%d3		| #-0x8000 -> d3
+	cmpl	%d3,%d0
 	jlt	retz
 # endif
 
 	| internal entry for floating point package, saves time
 	| d0=u.exp, d2=u.sign, d1=rounding bits, d4/d5=mantissa
 	| registers d2-d7 must be saved on the stack !
-___norm_df:
+C_SYMBOL_NAME(__norm_df):
 #ifdef __mcoldfire__
-	movel	#0xffff,d3	| clean high words of arguments
-	andl	d3,d0
-	andl	d3,d1
-	andl	d3,d2
+	movel	#0xffff,%d3	| clean high words of arguments
+	andl	%d3,%d0
+	andl	%d3,%d1
+	andl	%d3,%d2
 #endif
-	movel	d4,d3		| rounding and u.mant == 0 ?
-	orl	d5,d3
+	movel	%d4,%d3		| rounding and u.mant == 0 ?
+	orl	%d5,%d3
 	jne	1f
-	tstb	d1
+	tstb	%d1
 	jeq	retzok
 1:
-	movel	d4,d3
-	andl	#0xfffff000,d3	| fast shift, 16 bits ?
+	movel	%d4,%d3
+	andl	#0xfffff000,%d3	| fast shift, 16 bits ?
 	jne	2f
-	cmpw	#9,d0		| shift is going to far; do normal shift
+	cmpw	#9,%d0		| shift is going to far; do normal shift
 	jle	2f		|  (minimize shifts here : 10l = 16l + 6r)
-	swap	d4		| yes, swap register halfs
-	swap	d5
-	movew	d5,d4
-	moveb	d1,d5		| some doubt about this one !
+	swap	%d4		| yes, swap register halfs
+	swap	%d5
+	movew	%d5,%d4
+	moveb	%d1,%d5		| some doubt about this one !
 #ifdef __mcoldfire__
-	movew	d5,d3
-	lsll	#8,d3
-	movew	d3,d5
+	movew	%d5,%d3
+	lsll	#8,%d3
+	movew	%d3,%d5
 #else
-	lslw	#8,d5
+	lslw	#8,%d5
 #endif
-	clrw	d1
+	clrw	%d1
 #ifdef __mcoldfire__
-	subl	#16,d0		| account for swap
+	subl	#16,%d0		| account for swap
 #else
-	subw	#16,d0		| account for swap
+	subw	#16,%d0		| account for swap
 #endif
 	jra	1b
 2:
 #ifdef __mcoldfire__
-	andil	#0xffffff00,d2	| sticky byte
+	andil	#0xffffff00,%d2	| sticky byte
 #else
-	clrb	d2		| sticky byte
+	clrb	%d2		| sticky byte
 #endif
-	movel	#0xffe00000,d6
-3:	tstw	d0		| divide (shift)
+	movel	#0xffe00000,%d6
+3:	tstw	%d0		| divide (shift)
 	jle	0f		|  denormalized number
-	movel	d4,d3
-	andl	d6,d3		|  or until no bits above 53
+	movel	%d4,%d3
+	andl	%d6,%d3		|  or until no bits above 53
 	jeq	4f
 #ifdef __mcoldfire__
-0:	addl	#1,d0		| increment exponent
-	movew	d4,d3		| backup bit 0 of highest long
-	lsrl	#1,d4
-	lsrl	#1,d5
-	lsrl	#1,d1		| shift into rounding bits
-	btst	#0,d3
+0:	addl	#1,%d0		| increment exponent
+	movew	%d4,%d3		| backup bit 0 of highest long
+	lsrl	#1,%d4
+	lsrl	#1,%d5
+	lsrl	#1,%d1		| shift into rounding bits
+	btst	#0,%d3
 	jeq	33f
-	bset	#31,d5
-	bset	#7,d1
-33:	orl	d1,d2		| set sticky
+	bset	#31,%d5
+	bset	#7,%d1
+33:	orl	%d1,%d2		| set sticky
 #else
-0:	addw	#1,d0		| increment exponent
-	lsrl	#1,d4
-	roxrl	#1,d5
-	orb	d1,d2		| set sticky
-	roxrb	#1,d1		| shift into rounding bits
+0:	addw	#1,%d0		| increment exponent
+	lsrl	#1,%d4
+	roxrl	#1,%d5
+	orb	%d1,%d2		| set sticky
+	roxrb	#1,%d1		| shift into rounding bits
 #endif
 	jra	3b
 4:
 #ifdef __mcoldfire__
-	andl	#0xffffff01,d2
-	movel	d2,d3
-	andil	#1,d3
-	orl	d3,d1		| make least sig bit sticky
+	andl	#0xffffff01,%d2
+	movel	%d2,%d3
+	andil	#1,%d3
+	orl	%d3,%d1		| make least sig bit sticky
 #else
-	andb	#1,d2
-	orb	d2,d1		| make least sig bit sticky
+	andb	#1,%d2
+	orb	%d2,%d1		| make least sig bit sticky
 #endif
-	asrl	#1,d6		| #0xfff00000 -> d6
-5:	movel	d4,d3		| multiply (shift) until
-	andl	d6,d3		| one in implied position
+	asrl	#1,%d6		| #0xfff00000 -> d6
+5:	movel	%d4,%d3		| multiply (shift) until
+	andl	%d6,%d3		| one in implied position
 	jne	6f
 #ifdef __mcoldfire__
-	subl	#1,d0		| decrement exponent
+	subl	#1,%d0		| decrement exponent
 #else
-	subw	#1,d0		| decrement exponent
+	subw	#1,%d0		| decrement exponent
 #endif
 	jeq	6f		|  too small. store as denormalized number
 #ifdef __mcoldfire__
-	addl	d1,d1		| some doubt about this one *
+	addl	%d1,%d1		| some doubt about this one *
 #else
-	addb	d1,d1		| some doubt about this one *
+	addb	%d1,%d1		| some doubt about this one *
 #endif
-	addxl	d5,d5
-	addxl	d4,d4
+	addxl	%d5,%d5
+	addxl	%d4,%d4
 	jra	5b
 6:
-	tstb	d1		| check rounding bits
+	tstb	%d1		| check rounding bits
 	jge	8f		| round down - no action neccessary
 #ifdef __mcoldfire__
-	cmpb	#0x80,d1
+	cmpb	#0x80,%d1
 	jne	7f		| round up
-        movew   d5,d1           | tie case - round to even
+        movew   %d5,%d1           | tie case - round to even
                                 | dont need rounding bits any more
-        andl    #1,d1           | check if even
+        andl    #1,%d1           | check if even
 #else
-	negb	d1
+	negb	%d1
 	jvc	7f		| round up
-        movew   d5,d1           | tie case - round to even
+        movew   %d5,%d1           | tie case - round to even
                                 | dont need rounding bits any more
-        andw    #1,d1           | check if even
+        andw    #1,%d1           | check if even
 #endif
         jeq     8f              | mantissa is even - no action necessary
                                 | fall through
 7:
-	clrl	d1		| zero rounding bits
-	addl	#1,d5
-	addxl	d1,d4
-	tstw	d0
+	clrl	%d1		| zero rounding bits
+	addl	#1,%d5
+	addxl	%d1,%d4
+	tstw	%d0
 	jne	0f		| renormalize if number was denormalized
 #ifdef __mcoldfire__
-	addl	#1,d0		| correct exponent for denormalized numbers
+	addl	#1,%d0		| correct exponent for denormalized numbers
 #else
-	addw	#1,d0		| correct exponent for denormalized numbers
+	addw	#1,%d0		| correct exponent for denormalized numbers
 #endif
 	jra	2b
-0:	movel	d4,d3		| check for rounding overflow
-	asll	#1,d6		| #0xffe00000 -> d3
-	andl	d6,d3
+0:	movel	%d4,%d3		| check for rounding overflow
+	asll	#1,%d6		| #0xffe00000 -> d3
+	andl	%d6,%d3
 	jne	2b		| go back and renormalize
 8:
-	movel	d4,d3		| check if normalization caused an underflow
-	orl	d5,d3
+	movel	%d4,%d3		| check if normalization caused an underflow
+	orl	%d5,%d3
 	jeq	retz
-	tstw	d0		| check for exponent overflow or underflow
+	tstw	%d0		| check for exponent overflow or underflow
 	jlt	retz
-	cmpw	#2047,d0
+	cmpw	#2047,%d0
 	jge	oflow
 
 #ifdef __mcoldfire__
-	swap	d0		| map to upper word
-	lsll	#4,d0		| re-position exponent
-	andil	#0x7ff00000,d0
-	btst	#15,d2
+	swap	%d0		| map to upper word
+	lsll	#4,%d0		| re-position exponent
+	andil	#0x7ff00000,%d0
+	btst	#15,%d2
 	jeq	9f
-	bset 	#31,d0
+	bset 	#31,%d0
 9:
 #else
-	lslw	#5,d0		| re-position exponent - one bit too high
-	lslw	#1,d2		| get X bit
-	roxrw	#1,d0		| shift it into sign position
-	swap	d0		| map to upper word
-	clrw	d0
+	lslw	#5,%d0		| re-position exponent - one bit too high
+	lslw	#1,%d2		| get X bit
+	roxrw	#1,%d0		| shift it into sign position
+	swap	%d0		| map to upper word
+	clrw	%d0
 #endif
-	andl	#0x0fffff,d4	| top mantissa bits
-	orl	d0,d4		| insert exponent and sign
-	movel	d4,d0
-	movel	d5,d1
+	andl	#0x0fffff,%d4	| top mantissa bits
+	orl	%d0,%d4		| insert exponent and sign
+	movel	%d4,%d0
+	movel	%d5,%d1
 #ifdef __mcoldfire__
-	moveml	sp@,d2-d7
-	lea	sp@(24),sp
+	moveml	%sp@,%d2-%d7
+	lea	%sp@(24),%sp
 #else
-	moveml	sp@+,d2-d7
+	moveml	%sp@+,%d2-%d7
 #endif
 	rts
 
 retz:
-	moveq	#Erange,d0
-	Emove   d0,Errno
+	moveq	#Erange,%d0
+	Emove   %d0,Errno
 retzok:
-	moveq	#0,d0		| return zero value
-	movel	d0,d1
+	moveq	#0,%d0		| return zero value
+	movel	%d0,%d1
 #ifdef __mcoldfire__
-	movw	d2,d0
-	swap	d0
-	andil	#0x80000000,d0
-0:	moveml	sp@,d2-d7
-	lea	sp@(24),sp
+	movw	%d2,%d0
+	swap	%d0
+	andil	#0x80000000,%d0
+0:	moveml	%sp@,%d2-%d7
+	lea	%sp@(24),%sp
 #else
-	lslw	#1,d2		| set value of extension
-	roxrl	#1,d0		| and move it to hight bit of d0
-0:	moveml	sp@+,d2-d7
+	lslw	#1,%d2		| set value of extension
+	roxrl	#1,%d0		| and move it to hight bit of d0
+0:	moveml	%sp@+,%d2-%d7
 #endif
 	rts
 
 oflow:
 #ifdef	ERROR_CHECK
-	pea	pc@(LC0)
-	pea	Stderr
-	jbsr	_fprintf	|
-	addql	#8,a7		|
-	moveq	#Erange,d0
-	Emove	d0,Errno
+	pea	%pc@(LC0)
+	movel	Stderr,%sp@-
+	jbsr	C_SYMBOL_NAME(fprintf)	|
+	addql	#8,%%sp		|
+	moveq	#Erange,%d0
+	Emove	%d0,Errno
 #endif	/* ERROR_CHECK */
 
-|	moveml	pc@(__infinitydf),d0-d1 | return infinity value
+|	moveml	%pc@(C_SYMBOL_NAME(_infinitydf)),%d0-%d1 | return infinity value
 #ifdef __mcoldfire__
-	movel	__infinitydf,d0	| return infinty value
-	movel	__infinitydf+4,d1
+	movel	C_SYMBOL_NAME(_infinitydf),%d0	| return infinty value
+	movel	C_SYMBOL_NAME(_infinitydf+4),%d1
 #else
-	moveml	__infinitydf,d0-d1 | return infinty value
+	moveml	C_SYMBOL_NAME(_infinitydf),%d0-%d1 | return infinty value
 #endif
-	tstw	d2
+	tstw	%d2
 	jpl	1f
-	bset	#31,d0
+	bset	#31,%d0
 1:
 #ifdef __mcoldfire__
-	moveml	sp@,d2-d7	| should really cause trap ?!? (mjr: why?)
-	lea	sp@(24),sp
+	moveml	%sp@,%d2-%d7	| should really cause trap ?!? (mjr: why?)
+	lea	%sp@(24),%sp
 #else
-	moveml	sp@+,d2-d7	| should really cause trap ?!? (mjr: why?)
+	moveml	%sp@+,%d2-%d7	| should really cause trap ?!? (mjr: why?)
 #endif
 	rts
 

--- a/mintlib/checkcpu.S
+++ b/mintlib/checkcpu.S
@@ -20,24 +20,26 @@
 | pseudo-jump instructions must be avoided (jbsr, jbra...), because they may
 | be translated to unsupported jump instructions.
 
-	.extern	_Getcookie		| int Getcookie(long cookie, long *val);
+#include "libc-symbols.h"
 
-	.globl	__checkcpu
-__checkcpu:
+	.extern	C_SYMBOL_NAME(Getcookie)		| int Getcookie(long cookie, long *val);
+
+	.globl	C_SYMBOL_NAME(_checkcpu)
+C_SYMBOL_NAME(_checkcpu):
 #ifdef __M68020__
-	subql	#4,sp			| Local variable for cookie value
+	subql	#4,%sp			| Local variable for cookie value
 
-	pea	sp@
-	movl	#0x5f435055,sp@-	| "_CPU"
-	jsr	_Getcookie
-	addql	#8,sp
+	pea	%sp@
+	movl	#0x5f435055,%sp@-	| "_CPU"
+	jsr	C_SYMBOL_NAME(Getcookie)
+	addql	#8,%sp
 
-	movel	sp@+,d1			| Cookie value
+	movel	%sp@+,%d1			| Cookie value
 
-	tstl	d0
+	tstl	%d0
 	bnes	.bad020			| _CPU cookie not found
 
-	cmpl	#20,d1
+	cmpl	#20,%d1
 	bhss	.ok020			| CPU >= 68020
 
 .bad020:
@@ -53,16 +55,16 @@ __checkcpu:
 #endif
 
 #ifdef __mcoldfire__
-	subql	#4,sp			| Local variable for cookie value
+	subql	#4,%sp			| Local variable for cookie value
 
-	pea	sp@
-	movl	#0x5f43465f,sp@-	| "_CF_"
-	jsr	_Getcookie
-	addql	#8,sp
+	pea	%sp@
+	movl	#0x5f43465f,%sp@-	| "_CF_"
+	jsr	C_SYMBOL_NAME(Getcookie)
+	addql	#8,%sp
 
-	movel	sp@+,d1			| Cookie value
+	movel	%sp@+,%d1			| Cookie value
 
-	tstl	d0
+	tstl	%d0
 	beqs	.okv4e			| _CF_ cookie found
 
 	pea	.errv4e			| Error message
@@ -77,19 +79,19 @@ __checkcpu:
 #endif
 
 #ifdef __M68881__
-	subql	#4,sp			| Local variable for cookie value
+	subql	#4,%sp			| Local variable for cookie value
 
-	pea	sp@
-	movl	#0x5f465055,sp@-	| "_FPU"
-	jsr	_Getcookie
-	addql	#8,sp
+	pea	%sp@
+	movl	#0x5f465055,%sp@-	| "_FPU"
+	jsr	C_SYMBOL_NAME(Getcookie)
+	addql	#8,%sp
 
-	movel	sp@+,d1			| Cookie value
+	movel	%sp@+,%d1			| Cookie value
 
-	tstl	d0
+	tstl	%d0
 	bnes	.bad881			| _FPU cookie not found
 
-	tstl	d1
+	tstl	%d1
 	bnes	.ok881			| FPU present
 
 .bad881:
@@ -108,10 +110,10 @@ __checkcpu:
 | Print a message then exit.
 | The message must have been pushed on the stack.
 .printexit:
-	movew	#9,sp@-			| Cconws()
+	movew	#9,%sp@-			| Cconws()
 	trap	#1
-	addql	#6,sp
+	addql	#6,%sp
 
-	movew	#-1,sp@-		| Failure
-	movew	#0x4c,sp@-		| Pterm()
+	movew	#-1,%sp@-		| Failure
+	movew	#0x4c,%sp@-		| Pterm()
 	trap	#1

--- a/mintlib/errbase.h
+++ b/mintlib/errbase.h
@@ -5,13 +5,13 @@
 
 #include "errno.h"
 
-	.globl	_errno
+	.globl	C_SYMBOL_NAME(errno)
 
 Edom	= EDOM
 Erange	= ERANGE
 
-#define Errno	_errno
-#define Stderr	__iob+52
+#define Errno	C_SYMBOL_NAME(errno)
+#define Stderr	C_SYMBOL_NAME(stderr)
 
 #ifdef __MSHORT__
 #define Emove	movew

--- a/mintlib/frexp.S
+++ b/mintlib/frexp.S
@@ -1,3 +1,5 @@
+#include "libc-symbols.h"
+
 #if !defined (__M68881__) && !defined (sfp004)
 #
  |-----------------------------------------------------------------------------
@@ -19,91 +21,91 @@
 BIAS8	=	0x3ff - 1
 
 	.text; .even
-	.globl _frexp
-_frexp:
-	movel	sp@(12),a0	| initialize exponent for loop
+	.globl C_SYMBOL_NAME(frexp)
+C_SYMBOL_NAME(frexp):
+	movel	%sp@(12),%a0	| initialize exponent for loop
 #ifdef __MSHORT__
-	clrw	a0@
+	clrw	%a0@
 #else
-	clrl	a0@
+	clrl	%a0@
 #endif
-	lea	sp@(4),a1	| sp@(4) -> a1 - an address of value
+	lea	%sp@(4),%a1	| sp@(4) -> a1 - an address of value
 |				|   and a1@(8) - an address of *eptr
-	movel	a1@,d0		| keep value.sign
-	movel	d0,d1
-	bclr	#31,d1		| kill sign bit
-	tstl	d1		| 1st arg == 0 ?
+	movel	%a1@,%d0		| keep value.sign
+	movel	%d0,%d1
+	bclr	#31,%d1		| kill sign bit
+	tstl	%d1		| 1st arg == 0 ?
 	jne	nonzero
-	tstl	a1@(4)
+	tstl	%a1@(4)
 	jne	nonzero
 	rts			| if 0 or -0 then d0 and d1 already set
 nonzero:
-	movel	d2,sp@-
+	movel	%d2,%sp@-
 2:				| return here when looping
-	swap	d0		| sign and exponent into lower 16 bits
-	movew	d0,d2		| set d2 for norm_df
+	swap	%d0		| sign and exponent into lower 16 bits
+	movew	%d0,%d2		| set d2 for norm_df
 #ifdef __mcoldfire__
-	andil	#0x7fff,d0	| kill sign bit
-	lsrl	#4,d0
+	andil	#0x7fff,%d0	| kill sign bit
+	lsrl	#4,%d0
 #else
-	bclr	#15,d0		| kill sign bit
-	lsrw	#4,d0
+	bclr	#15,%d0		| kill sign bit
+	lsrw	#4,%d0
 #endif
 
-	cmpw	#BIAS8,d0	| get out of loop if finally (a1) in [0.5,1.0)
+	cmpw	#BIAS8,%d0	| get out of loop if finally (a1) in [0.5,1.0)
 	jeq	3f
 
-	moveq	#0x0f,d1	| remove exponent from value.mantissa
+	moveq	#0x0f,%d1	| remove exponent from value.mantissa
 #ifdef __mcoldfire__
-	andl	d2,d1		| four upper bits of value in d1
+	andl	%d2,%d1		| four upper bits of value in %d1
 #else
-	andb	d2,d1		| four upper bits of value in d1
+	andb	%d2,%d1		| four upper bits of value in %d1
 #endif
-	bset	#4,d1		| implied leading 1
-	tstw	d0		| check for zero exponent
+	bset	#4,%d1		| implied leading 1
+	tstw	%d0		| check for zero exponent
 	jne	1f
 #ifdef __mcoldfire__
-	addql	#1,d0
+	addql	#1,%d0
 #else
-	addqw	#1,d0
+	addqw	#1,%d0
 #endif
-	bclr	#4,d1		| nah, we do not need stinkin leadin 1
-1:	movew	d1,a1@		| save results of our efforts
+	bclr	#4,%d1		| nah, we do not need stinkin leadin 1
+1:	movew	%d1,%a1@		| save results of our efforts
 
-	movel	a1@,d1		| check for zero
-	orl	a1@(4),d1
+	movel	%a1@,%d1		| check for zero
+	orl	%a1@(4),%d1
 	jeq	3f		| if zero, all done : exp = 0, num = 0.0
 				| sign of zero is correct
 #ifdef __mcoldfire__
-	subl	#BIAS8,d0	| remove bias
+	subl	#BIAS8,%d0	| remove bias
 #else
-	subw	#BIAS8,d0	| remove bias
+	subw	#BIAS8,%d0	| remove bias
 #endif
 #ifdef __MSHORT__
-	addw	d0,a0@		| add current exponent in
+	addw	%d0,%a0@		| add current exponent in
 #else
-	extl	d0
-	addl	d0,a0@		| add current exponent in
+	extl	%d0
+	addl	%d0,%a0@		| add current exponent in
 #endif
 
-	movew	#BIAS8,d0	| set bias for return value
-	clrw	d1		| rounding = 0
+	movew	#BIAS8,%d0	| set bias for return value
+	clrw	%d1		| rounding = 0
 	pea	L0		| call to norm_df (dirty, but dont ...
 #ifdef __mcoldfire__
-	lea	sp@(-24),sp
-	moveml	d2-d7,sp@	| ... need to copy with -mshort)
+	lea	%sp@(-24),%sp
+	moveml	%d2-%d7,%sp@	| ... need to copy with -mshort)
 #else
-	moveml	d2-d7,sp@-	| ... need to copy with -mshort)
+	moveml	%d2-%d7,%sp@-	| ... need to copy with -mshort)
 #endif
-	moveml	a1@,d4-d5
-	jmp	___norm_df	| normalize result
+	moveml	%a1@,%d4-%d5
+	jmp	C_SYMBOL_NAME(__norm_df)	| normalize result
 L0:				| norm_df does not affect a0 or a1
-|				| but it pops d2-d7
-	moveml	d0-d1,a1@
+|				| but it pops %d2-%d7
+	moveml	%d0-%d1,%a1@
 	jra	2b		| loop around to catch denormalized numbers
 3:
-	moveml	a1@,d0-d1
-	movel	sp@+,d2
+	moveml	%a1@,%d0-%d1
+	movel	%sp@+,%d2
 				| d0-d1 has normalized mantissa
 	rts
 
@@ -127,32 +129,32 @@ L0:				| norm_df does not affect a0 or a1
 
 	.text; .even
 
-.globl _frexp
+.globl C_SYMBOL_NAME(frexp)
 
-_frexp:
-	moveal	a7@(12),a1		| address of n
-	fmoved	a7@(4),fp0		| load first_argument to fp0
-	fcmpd	#0r0.0,fp0		| 1st arg == 0 ?
+C_SYMBOL_NAME(frexp):
+	moveal	%sp@(12),%a1		| address of n
+	fmoved	%sp@(4),%fp0		| load first_argument to fp0
+	fcmpd	#0r0.0,%fp0		| 1st arg == 0 ?
 	fjeq	null_			| both parts of result are 0
-	fgetexpx fp0,fp1		| get expnent
-	fgetmanx fp0,fp0		| get mantissa
-	fscaleb #-1,fp0			|
+	fgetexpx %fp0,%fp1		| get expnent
+	fgetmanx %fp0,%fp0		| get mantissa
+	fscaleb #-1,%fp0			|
 #ifdef __MSHORT__
-	fmovew	fp1,a1@			| fetch exp (fmovew from fp1)
-	addqw	#1,a1@			| correct result
+	fmovew	%fp1,%a1@			| fetch exp (fmovew from fp1)
+	addqw	#1,%a1@			| correct result
 #else
-	fmovel	fp1,a1@			| fetch exp (fmovel from fp1)
-	addql	#1,a1@			| correct result
+	fmovel	%fp1,%a1@			| fetch exp (fmovel from fp1)
+	addql	#1,%a1@			| correct result
 #endif
-	fmoved	fp0,a7@-		| now fetch significand
-	moveml	a7@+,d0-d1
+	fmoved	%fp0,%sp@-		| now fetch significand
+	moveml	%sp@+,%d0-%d1
 	rts
 null_:
-	moveml	a7@(4),d0-d1
+	moveml	%sp@(4),%d0-%d1
 #ifdef __MSHORT__
-	clrw	a1@
+	clrw	%a1@
 #else
-	clrl	a1@
+	clrl	%a1@
 #endif
 	rts
 
@@ -182,68 +184,68 @@ zahl =	  0	|	fpu data reg
 | waiting loop ...
 |
 | wait:
-| ww:	cmpiw	#0x8900,a0@(resp)
+| ww:	cmpiw	#0x8900,%a0@(resp)
 | 	beq	ww
 | is coded directly by
 |	.long	0x0c688900, 0xfff067f8                 (fpu base a1)
 | and
-| www:	tst.w	a0@(resp)
+| www:	tst.w	%a0@(resp)
 |	bmi.b	www
 | is coded by
 |	.word	0x4a68,0xfff0,0x6bfa		| test
 
 	.text; .even
 
-.globl _frexp
+.globl C_SYMBOL_NAME(frexp)
 
-_frexp:
-	tstl	sp@(4)		| 1st arg == 0 ?
+C_SYMBOL_NAME(frexp):
+	tstl	%sp@(4)		| 1st arg == 0 ?
 	jne	nonzero
-	tstl	sp@(8)
+	tstl	%sp@(8)
 	jne	nonzero
-	movel	sp@(12),a0
+	movel	%sp@(12),%a0
 #ifdef __MSHORT__
-	clrw	a0@
+	clrw	%a0@
 #else
-	clrl	a0@
+	clrl	%a0@
 #endif
-	clrl	d0
-	clrl	d1
+	clrl	%d0
+	clrl	%d1
 	rts
 nonzero:
-	lea	0xfffffa50:w,a0
-	movew	#0x5418,a0@(comm)	| load first argument to fp0
-	cmpiw	#0x8900,a0@(resp)	| check
-	movel	a7@(4),a0@
-	movel	a7@(8),a0@
+	lea	0xfffffa50:w,%a0
+	movew	#0x5418,%a0@(comm)	| load first argument to fp0
+	cmpiw	#0x8900,%a0@(resp)	| check
+	movel	%sp@(4),%a0@
+	movel	%sp@(8),%a0@
 
-	movew	#0x009f,a0@(comm)	| fgetman fp0,fp1
+	movew	#0x009f,%a0@(comm)	| fgetman %fp0,%fp1
 	.word	0x4a68,0xfff0,0x6bfa	| test
 
-	movew	#0x001e,a0@(comm)	| fgetexp fp0,fp0
-	moveal	a7@(12),a1		| address of n while the fpu is active
+	movew	#0x001e,%a0@(comm)	| fgetexp %fp0,%fp0
+	moveal	%sp@(12),%a1		| address of n while the fpu is active
 	.word	0x4a68,0xfff0,0x6bfa	| test
 
-	movew	#5026,a0@(comm)		| fscalew #-1,fp0
+	movew	#5026,%a0@(comm)		| fscalew #-1,%fp0
 	.long	0x0c688900, 0xfff067f8
-	movew	#-1,a0@
+	movew	#-1,%a0@
 
 #ifdef __MSHORT__
-	movew	#0x7080,a0@(comm)	| fetch exp (fmovew from fp1)
+	movew	#0x7080,%a0@(comm)	| fetch exp (fmovew from fp1)
 	.long	0x0c688900, 0xfff067f8
-	movew	a0@,a1@			| return exp
+	movew	%a0@,%a1@			| return exp
 #else
-	movew	#0x6080,a0@(comm)	| fetch exp (fmovel from fp1)
+	movew	#0x6080,%a0@(comm)	| fetch exp (fmovel from fp1)
 	.long	0x0c688900, 0xfff067f8
-	movel	a0@,a1@			| return exp
+	movel	%a0@,%a1@			| return exp
 #endif
-	movew	#0x7400,a0@(comm)	| now fetch significand
+	movew	#0x7400,%a0@(comm)	| now fetch significand
 	.long	0x0c688900, 0xfff067f8
-	movel	a0@,d0
-	movel	a0@,d1
-	btst	#31,a7@(4)		| test sign of 1st arg
+	movel	%a0@,%d0
+	movel	%a0@,%d1
+	btst	#31,%sp@(4)		| test sign of 1st arg
 	jge	fini			| arg neg ?
-	bset	#31,d0			| =>  negate result
+	bset	#31,%d0			| =>  negate result
 fini:	rts
 
 #endif	/* sfp004 */

--- a/mintlib/getcookie.S
+++ b/mintlib/getcookie.S
@@ -17,78 +17,80 @@
 | pseudo-jump instructions must be avoided (jbsr, jbra...), because they may
 | be translated to unsupported jump instructions.
 
-	.extern	___has_no_ssystem	| int __has_no_ssystem;
-	.extern	_get_sysvar		| long get_sysvar(void *var);
+#include "libc-symbols.h"
 
-	.globl	_Getcookie
-_Getcookie:
-	lea	sp@(-16),sp
-	movml	d2/d3/a2/a3,sp@		| ColdFire compatibility
+	.extern	C_SYMBOL_NAME(__has_no_ssystem)	| int __has_no_ssystem;
+	.extern	C_SYMBOL_NAME(get_sysvar)		| long get_sysvar(void *var);
 
-	movel	sp@(16+4),d3		| cookie
-	movel	sp@(16+8),a3		| p_value
+	.globl	C_SYMBOL_NAME(Getcookie)
+C_SYMBOL_NAME(Getcookie):
+	lea	%sp@(-16),%sp
+	movml	%d2/%d3/%a2/%a3,%sp@		| ColdFire compatibility
 
-	tstl	___has_no_ssystem
+	movel	%sp@(16+4),%d3		| cookie
+	movel	%sp@(16+8),%a3		| p_value
+
+	tstl	C_SYMBOL_NAME(__has_no_ssystem)
 	beqs	.get_with_ssystem
 
 	pea	0x5a0			| _p_cookies
-	jsr	_get_sysvar
-	addql	#4,sp
+	jsr	C_SYMBOL_NAME(get_sysvar)
+	addql	#4,%sp
 
-	tstl	d0
+	tstl	%d0
 	beqs	.error			| No cookie jar
 
-	movl	d0,a0
+	movl	%d0,%a0
 
 .nextcookie:
-	tstl	a0@
+	tstl	%a0@
 	beqs	.error			| End of Cookie Jar
 
-	movel	a0@+,d0			| Cookie name
-	movel	a0@+,d1			| Cookie value
+	movel	%a0@+,%d0			| Cookie name
+	movel	%a0@+,%d1			| Cookie value
 
-	cmpl	d3,d0			| Right cookie ?
+	cmpl	%d3,%d0			| Right cookie ?
 	bnes	.nextcookie
 
-	moveq	#0,d0			| E_OK
+	moveq	#0,%d0			| E_OK
 
 .return:
-	cmpl	#0,a3
+	cmpl	#0,%a3
 	beqs	.restore		| p_value == NULL
 
-	movl	d1,a3@			| *p_value = value;
+	movl	%d1,%a3@			| *p_value = value;
 
 .restore:
-	movml	sp@,d2/d3/a2/a3		| ColdFire compatibility
-	lea	sp@(16),sp
+	movml	%sp@,%d2/%d3/%a2/%a3		| ColdFire compatibility
+	lea	%sp@(16),%sp
 	rts
 
 .error:
-	moveq	#-1,d0			| EERROR
-	moveq	#0,d1			| Cookie value
+	moveq	#-1,%d0			| EERROR
+	moveq	#0,%d1			| Cookie value
 
 	bras	.return
 
 .get_with_ssystem:
 	pea	-42			| Local variable for cookie value
 
-	pea	sp@			| Pointer to the output variable
-	movl	d3,sp@-			| cookie
-	movew	#8,sp@-			| S_GETCOOKIE
-	movew	#0x154,sp@-		| Ssystem()
+	pea	%sp@			| Pointer to the output variable
+	movl	%d3,%sp@-			| cookie
+	movew	#8,%sp@-			| S_GETCOOKIE
+	movew	#0x154,%sp@-		| Ssystem()
 	trap	#1
-	lea	sp@(12),sp
+	lea	%sp@(12),%sp
 
-	movel	sp@+,d1			| Cookie value
+	movel	%sp@+,%d1			| Cookie value
 
-	cmpl	#-1,d0
+	cmpl	#-1,%d0
 	beqs	.error			| Fail
 
 	| Backward compatibility for MiNT 1.14.7:
 	| Ssystem() returns cookie value and ignores arg2!!
-	cmpl	#-42,d1
+	cmpl	#-42,%d1
 	bnes	.return
 
-	movl	d0,d1			| Get value from return value
+	movl	%d0,%d1			| Get value from return value
 
 	bras	.return

--- a/mintlib/getsysvar.S
+++ b/mintlib/getsysvar.S
@@ -17,56 +17,58 @@
 | pseudo-jump instructions must be avoided (jbsr, jbra...), because they may
 | be translated to unsupported jump instructions.
 
-	.extern	___has_no_ssystem	| int __has_no_ssystem;
+#include "libc-symbols.h"
 
-	.globl	_get_sysvar
-_get_sysvar:
-	lea	sp@(-16),sp
-	movml	d2/d3/a2/a3,sp@		| ColdFire compatibility
+	.extern	C_SYMBOL_NAME(__has_no_ssystem)	| int __has_no_ssystem;
 
-	movel	sp@(16+4),a3		| var
+	.globl	C_SYMBOL_NAME(get_sysvar)
+C_SYMBOL_NAME(get_sysvar):
+	lea	%sp@(-16),%sp
+	movml	%d2/%d3/%a2/%a3,%sp@		| ColdFire compatibility
 
-	tstl	___has_no_ssystem
+	movel	%sp@(16+4),%a3		| var
+
+	tstl	C_SYMBOL_NAME(__has_no_ssystem)
 	beqs	.get_with_ssystem
 
-	movel	#1,sp@-			| SUP_INQUIRE
-	movew	#0x20,sp@-		| Super()
+	movel	#1,%sp@-			| SUP_INQUIRE
+	movew	#0x20,%sp@-		| Super()
 	trap	#1
-	addql	#6,sp
+	addql	#6,%sp
 
-	tstl	d0
+	tstl	%d0
 	beqs	.get_usermode		| We are in user mode
 
-	movel	a3@,d0			| Read the variable directly
+	movel	%a3@,%d0			| Read the variable directly
 
 .return:
-	movml	sp@,d2/d3/a2/a3		| ColdFire compatibility
-	lea	sp@(16),sp
+	movml	%sp@,%d2/%d3/%a2/%a3		| ColdFire compatibility
+	lea	%sp@(16),%sp
 	rts
 
 .get_with_ssystem:
-	clrl	sp@-
-	movl	a3,sp@-			| var
-	movew	#10,sp@-		| S_GETLVAL
-	movew	#0x154,sp@-		| Ssystem()
+	clrl	%sp@-
+	movl	%a3,%sp@-			| var
+	movew	#10,%sp@-		| S_GETLVAL
+	movew	#0x154,%sp@-		| Ssystem()
 	trap	#1
-	lea	sp@(12),sp
+	lea	%sp@(12),%sp
 
 	bras	.return
 
 .get_usermode:
-	clrl	sp@-			| SUP_SET
-	movew	#0x20,sp@-		| Super()
+	clrl	%sp@-			| SUP_SET
+	movew	#0x20,%sp@-		| Super()
 	trap	#1			| Switch to supervisor mode
-	addql	#6,sp
+	addql	#6,%sp
 
-	movel	a3@,d3			| Get the variable value
+	movel	%a3@,%d3			| Get the variable value
 
-	movel	d0,sp@-			| Old SSP
-	movew	#0x20,sp@-		| Super()
+	movel	%d0,%sp@-			| Old SSP
+	movew	#0x20,%sp@-		| Super()
 	trap	#1			| Restore user mode
-	addql	#6,sp
+	addql	#6,%sp
 
-	movel	d3,d0
+	movel	%d3,%d0
 
 	bras	.return

--- a/mintlib/ldexp.S
+++ b/mintlib/ldexp.S
@@ -1,6 +1,8 @@
+#include "libc-symbols.h"
+
 	.text
-	.globl _ldexp
-	.globl __infinitydf
+	.globl C_SYMBOL_NAME(ldexp)
+	.globl C_SYMBOL_NAME(_infinitydf)
 	.even
 #ifdef	ERROR_CHECK
 #include "errbase.h"
@@ -28,7 +30,7 @@ m_Inf:
 # endif
 	.even
 #endif	/* ERROR_CHECK */
-_ldexp:
+C_SYMBOL_NAME(ldexp):
 #if !defined (__M68881__) && !defined (sfp004)
 
  | add exponent to floating point number
@@ -45,95 +47,95 @@ _ldexp:
  |  #5  make returned zero signed				  mj,  05/93
  |-----------------------------------------------------------------------------
 
-	lea	sp@(4),a1
+	lea	%sp@(4),%a1
 #ifdef __mcoldfire__
-	lea	sp@(-24),sp
-	moveml	d2-d7,sp@	| save d2-d7
+	lea	%sp@(-24),%sp
+	moveml	%d2-%d7,%sp@	| save d2-d7
 #else
-	moveml	d2-d7,sp@-	| save d2-d7
+	moveml	%d2-%d7,%sp@-	| save d2-d7
 #endif
 
-	movew	a1@,d0		| extract value.exp
-	movew	d0,d2		| extract value.sign
+	movew	%a1@,%d0		| extract value.exp
+	movew	%d0,%d2		| extract value.sign
 #ifdef __mcoldfire__
-	andil	#0x7fff,d0	| kill sign bit
-	lsrl	#4,d0
+	andil	#0x7fff,%d0	| kill sign bit
+	lsrl	#4,%d0
 #else
-	bclr	#15,d0		| kill sign bit
-	lsrw	#4,d0
+	bclr	#15,%d0		| kill sign bit
+	lsrw	#4,%d0
 #endif
 
-	moveq	#0x0f,d3	| remove exponent from value.mantissa
+	moveq	#0x0f,%d3	| remove exponent from value.mantissa
 #ifdef __mcoldfire__
-	andl	d2,d3		| four upper bits of value in d3
+	andl	%d2,%d3		| four upper bits of value in d3
 #else
-	andb	d2,d3		| four upper bits of value in d3
+	andb	%d2,%d3		| four upper bits of value in d3
 #endif
-	bset	#4,d3		| implied leading 1
-	tstw	d0		| check for zero exponent
+	bset	#4,%d3		| implied leading 1
+	tstw	%d0		| check for zero exponent
 	jne	1f
 #ifdef __mcoldfire__
-	addql	#1,d0
+	addql	#1,%d0
 #else
-	addqw	#1,d0
+	addqw	#1,%d0
 #endif
-	bclr	#4,d3		| nah, we do not need stinkin leadin 1
-1:	movew	d3,a1@		| save results of our efforts
+	bclr	#4,%d3		| nah, we do not need stinkin leadin 1
+1:	movew	%d3,%a1@		| save results of our efforts
 #ifdef __MSHORT__
-	addw	a1@(8),d0	| add in exponent
-	extl	d0
+	addw	%a1@(8),%d0	| add in exponent
+	extl	%d0
 #else
-	extl	d0
-	addl	a1@(8),d0	| add in exponent
+	extl	%d0
+	addl	%a1@(8),%d0	| add in exponent
 #endif
-	cmpl	#-53,d0		| hmm. works only if 1 in implied position...
+	cmpl	#-53,%d0		| hmm. works only if 1 in implied position...
 	jle	retz		| range error - underflow
-	cmpl	#0x7ff,d0
+	cmpl	#0x7ff,%d0
 	jge	rangerr		| range error - overflow
 
-	clrw	d1		| zero rounding bits
-	moveml	a1@,d4-d5	| value into d4,d5
-	jmp	___norm_df	| norm_df will pop d2-d7 and rts
+	clrw	%d1		| zero rounding bits
+	moveml	%a1@,%d4-%d5	| value into d4,d5
+	jmp	C_SYMBOL_NAME(__norm_df)	| norm_df will pop d2-d7 and rts
 
 retz:
-	moveq	#0,d0		| zero return value
-	movel	d0,d1
+	moveq	#0,%d0		| zero return value
+	movel	%d0,%d1
 #ifdef __mcoldfire__
-	btst	#15,d2
+	btst	#15,%d2
 	jeq	L0
-	bset 	#31,d0
+	bset 	#31,%d0
 #else
-	lslw	#1,d2		| transfer argument sign
-	roxrl	#1,d0
+	lslw	#1,%d2		| transfer argument sign
+	roxrl	#1,%d0
 #endif
 	jra	L0
 
 rangerr:
 
 #ifdef ERROR_CHECK
-	moveq	#Erange,d0
-	Emove	d0,Errno
-	pea	pc@(_Overflow)	| for printf
-	pea	Stderr		|
-	jbsr	_fprintf	|
-	addql	#8,a7		|
+	moveq	#Erange,%d0
+	Emove	%d0,Errno
+	pea	%pc@(_Overflow)	| for printf
+	movel Stderr,%sp@-		|
+	jbsr	C_SYMBOL_NAME(fprintf)	|
+	addql	#8,%sp		|
 #endif /* ERROR_CHECK */
 
 #ifdef __mcoldfire__
-	movel	__infinitydf,d0    | return HUGE_VAL (same as in <math.h>)
-	movel	__infinitydf+4,d1
+	movel	C_SYMBOL_NAME(_infinitydf),%d0    | return HUGE_VAL (same as in <math.h>)
+	movel	C_SYMBOL_NAME(_infinitydf+4),%d1
 #else
-	moveml	__infinitydf,d0-d1 | return HUGE_VAL (same as in <math.h>)
+	moveml	C_SYMBOL_NAME(_infinitydf),%d0-%d1 | return HUGE_VAL (same as in <math.h>)
 #endif
-	tstw	d2
+	tstw	%d2
 	jge	L0
-	bset	#31,d0
+	bset	#31,%d0
 L0:
 #ifdef __mcoldfire__
-	moveml	sp@,d2-d7	| pop saved reggies
-	lea	sp@(24),sp
+	moveml	%sp@,%d2-%d7	| pop saved reggies
+	lea	%sp@(24),%sp
 #else
-	moveml	sp@+,d2-d7	| pop saved reggies
+	moveml	%sp@+,%d2-%d7	| pop saved reggies
 #endif
 	rts
 
@@ -154,19 +156,19 @@ L0:
 |##############################################################################
 
 #ifdef __MSHORT__
-	movew	a7@(12),d0		| get exponent
-	extl	d0
+	movew	%sp@(12),%d0		| get exponent
+	extl	%d0
 #else
-	movel	a7@(12),d0		| get exponent
+	movel	%sp@(12),%d0		| get exponent
 #endif
-	fgetexpd a7@(4),fp1		| extract exponent of 1st arg
-	fmovel	fp1,d1			| d1 serves as accumulator
-	addl	d0,d1			| sum of exp_s of both args
+	fgetexpd %sp@(4),%fp1		| extract exponent of 1st arg
+	fmovel	%fp1,%d1			| d1 serves as accumulator
+	addl	%d0,%d1			| sum of exp_s of both args
 
-	ftwotoxl d0,fp0			| ftwotox to fp0 (as long int!)
-	fmuld	a7@(4),fp0		| fmul value,fp0
-	fmoved	fp0,a7@-		| get double from fp0
-	moveml	a7@+,d0-d1
+	ftwotoxl %d0,%fp0			| ftwotox to fp0 (as long int!)
+	fmuld	%sp@(4),%fp0		| fmul value,fp0
+	fmoved	%fp0,%sp@-		| get double from fp0
+	moveml	%sp@+,%d0-%d1
 
 #endif  /* __M68881__ */
 #ifdef	sfp004
@@ -191,7 +193,7 @@ zahl =	  0	|	fpu data reg
 | waiting loop ...
 |
 | wait:
-| ww:	cmpiw	#0x8900,a1@(resp)
+| ww:	cmpiw	#0x8900,%a1@(resp)
 | 	beq	ww
 | is coded directly by
 |	.byte	0x0c,0x69,0x89,0x00,0xff,0xf0,0x67,0xf8 (a1)
@@ -199,60 +201,60 @@ zahl =	  0	|	fpu data reg
 |	.long	0x0c6889000, 0x000067f8			(a0)
 
 #ifdef __MSHORT__
-	movew	sp@(12),d0		| get exponent
-	extl	d0
+	movew	%sp@(12),%d0		| get exponent
+	extl	%d0
 #else
-	movel	sp@(12),d0		| get exponent
+	movel	%sp@(12),%d0		| get exponent
 #endif
-	lea	0xfffffa50:w,a0		| fpu address
-	movew	#0x549e,a0@(comm)	| fgetexpd sp@(4),fp1
-	cmpiw	#0x8900,a0@(resp)
-	movel	sp@(4),a0@
-	movel	sp@(8),a0@
-	movew	#0x6080,a0@(comm)	| fmovel fp1,d1
+	lea	0xfffffa50:w,%a0		| fpu address
+	movew	#0x549e,%a0@(comm)	| fgetexpd %sp@(4),%fp1
+	cmpiw	#0x8900,%a0@(resp)
+	movel	%sp@(4),%a0@
+	movel	%sp@(8),%a0@
+	movew	#0x6080,%a0@(comm)	| fmovel %fp1,%d1
 	.long	0x0c688900, 0xfff067f8
-	movel	a0@,d1
-	addl	d0,d1
-	movew	#0x4011,a0@(comm)	| ftwotoxl d0,fp0
+	movel	%a0@,%d1
+	addl	%d0,%d1
+	movew	#0x4011,%a0@(comm)	| ftwotoxl %d0,%fp0
 	.long	0x0c688900, 0xfff067f8
-	movel	d0,a0@
-	movew	#0x5423,a0@(comm)	| fmuld sp@(4),fp0
+	movel	%d0,%a0@
+	movew	#0x5423,%a0@(comm)	| fmuld %sp@(4),%fp0
 	.long	0x0c688900, 0xfff067f8
-	movel	sp@(4),a0@
-	movel	sp@(8),a0@
-	movew	#0x7400,a0@(comm)	| fmoved fp0,d0/d1
+	movel	%sp@(4),%a0@
+	movel	%sp@(8),%a0@
+	movew	#0x7400,%a0@(comm)	| fmoved %fp0,%d0/%d1
 	.long	0x0c688900, 0xfff067f8
-	movel	a0@,d0
-	movel	a0@,d1
+	movel	%a0@,%d0
+	movel	%a0@,%d1
 #endif	/* sfp004 */
 
 #ifdef	ERROR_CHECK
-	lea	double_max,a0	|
-	swap	d0		| exponent into lower word
-	cmpw	a0@(16),d0	| == NaN ?
+	lea	double_max,%a0	|
+	swap	%d0		| exponent into lower word
+	cmpw	%a0@(16),%d0	| == NaN ?
 	jeq	error_nan	|
-	cmpw	a0@(24),d0	| == + Infinity ?
+	cmpw	%a0@(24),%d0	| == + Infinity ?
 	jeq	error_plus	|
-	swap	d0		| result ok,
+	swap	%d0		| result ok,
 	rts			| restore d0
 error_plus:
-	swap	d0
-	moveml	d0-d1,a7@-	| print error message
-	moveq	#Erange,d0	| Overflow: errno = ERANGE
-	Emove	d0,Errno
-	pea	pc@(_Domain)	| for printf
+	swap	%d0
+	moveml	%d0-%d1,%sp@-	| print error message
+	moveq	#Erange,%d0	| Overflow: errno = ERANGE
+	Emove	%d0,Errno
+	pea	%pc@(_Domain)	| for printf
 	jra	error_exit	|
 error_nan:
-	moveq	#Edom,d0	| NAN => errno = EDOM
-	Emove	d0,Errno
-	moveml	a0@(24),d0-d1	| result = +inf
-	moveml	d0-d1,a7@-	| print error message
-	pea	pc@(_Overflow)	| for printf
+	moveq	#Edom,%d0	| NAN => errno = EDOM
+	Emove	%d0,Errno
+	moveml	%a0@(24),%d0-%d1	| result = +inf
+	moveml	%d0-%d1,%sp@-	| print error message
+	pea	%pc@(_Overflow)	| for printf
 error_exit:
-	pea	Stderr		|
-	jbsr	_fprintf	|
-	addql	#8,a7		|
-	moveml	a7@+,d0-d1
+	movel	Stderr,%sp@-		|
+	jbsr	C_SYMBOL_NAME(fprintf)	|
+	addql	#8,%sp		|
+	moveml	%sp@+,%d0-%d1
 #endif	/* ERROR_CHECK */
 	rts
 

--- a/mintlib/libc_exit.S
+++ b/mintlib/libc_exit.S
@@ -10,31 +10,32 @@
 | This file is in assembler to avoid it being profiled when compiling
 | with -pg.
 
-#include <libc-symbols.h>
+#include "libc-symbols.h"
+
 	.text
 	.even
-	.globl ___libc_exit, __exit
+	.globl C_SYMBOL_NAME(__libc_exit), C_SYMBOL_NAME(_exit)
 	weak_alias (__libc_exit, _exit)
 	weak_alias (__libc_exit, _Exit)
 	
-___libc_exit:
-	link a6,#0
+C_SYMBOL_NAME(__libc_exit):
+	link %a6,#0
 #ifdef __mcoldfire__
-	lea	sp@(-12),sp
-	moveml	d5/a4/a5,sp@
+	lea	%sp@(-12),%sp
+	moveml	%d5/%a4/%a5,%sp@
 #else
-	moveml	d5/a4/a5,sp@-
+	moveml	%d5/%a4/%a5,%sp@-
 #endif
 #ifndef __MSHORT__
-	movel a6@(8),d3
+	movel %a6@(8),%d3
 #else
-	movew a6@(8),d3
+	movew %a6@(8),%d3
 #endif
 | now on _mcleanup handled
-|	clrl sp@-
-|	jbsr __moncontrol
+|	clrl %sp@-
+|	jbsr C_SYMBOL_NAME(_moncontrol)
 	
-	jbsr ___mcleanup
-	movw	d3,sp@-
-	movw    #76,sp@-
+	jbsr C_SYMBOL_NAME(__mcleanup)
+	movw	%d3,%sp@-
+	movw    #76,%sp@-
 	trap    #1

--- a/mintlib/linea.c
+++ b/mintlib/linea.c
@@ -29,11 +29,13 @@
 #endif
 
 #ifdef __mcoldfire__
-	// On ColdFire V4e, the standard Line A opcodes
-	// conflict with some valid MAC instructions.
-	// Fortunately, the following range is always invalid
-	// and triggers the standard Line A exception.
-	// The ColdFire OS will keep only the last 4 bits
+	/*
+	 * On ColdFire V4e, the standard Line A opcodes
+	 * conflict with some valid MAC instructions.
+	 * Fortunately, the following range is always invalid
+	 * and triggers the standard Line A exception.
+	 * The ColdFire OS will keep only the last 4 bits
+	 */
 	#define LINEA_OPCODE_BASE 0xa920
 #else
 	#define LINEA_OPCODE_BASE 0xa000
@@ -144,7 +146,7 @@ void linea7(BBPB *P)
 	__asm__ volatile
 	(
 		PUSH_SP("%%d2/%%a2/%%a6", 12)
- 		"movl	%0,%%a6\n\t"
+		"movl	%0,%%a6\n\t"
 		ASM_LINEA(0x7) "\n\t"
 		POP_SP("%%d2/%%a2/%%a6", 12)
 	: 						  /* outputs */
@@ -206,7 +208,7 @@ void lineac(void *P)
 {
 	__asm__ volatile
 	(
- 		"movl	%0,%%a2\n\t"
+		"movl	%0,%%a2\n\t"
 		ASM_LINEA(0xc)
 	: 						  /* outputs */
 	: "r"(P)					  /* inputs  */
@@ -219,10 +221,10 @@ void linead(int x, int y,  SFORM * sd, void *ss)
 {
 	__asm__ volatile
 	(
- 		"movw	%0,%%d0\n\t"
- 		"movw	%1,%%d1\n\t"
- 		"movl	%2,%%a0\n\t"
- 		"movl	%3,%%a2\n\t"
+		"movw	%0,%%d0\n\t"
+		"movw	%1,%%d1\n\t"
+		"movl	%2,%%a0\n\t"
+		"movl	%3,%%a2\n\t"
 		ASM_LINEA(0xd)
 	: 						  /* outputs */
 	: "r"((short)x), "r"((short)y), "r"(sd), "r"(ss)  /* inputs  */

--- a/mintlib/modf.S
+++ b/mintlib/modf.S
@@ -1,3 +1,5 @@
+#include "libc-symbols.h"
+
 #if !defined (__M68881__) && !defined (sfp004)
 
  | take floating point to integer and fractional pieces
@@ -19,104 +21,105 @@
 
 BIAS8	=	0x3ff - 1
 
-	.text; .even
-	.globl _modf
-_modf:
-	lea	sp@(4),a0	| a0 -> float argument
+	.text
+	.even
+	.globl C_SYMBOL_NAME(modf)
+C_SYMBOL_NAME(modf):
+	lea	%sp@(4),%a0	| a0 -> float argument
 #ifdef __mcoldfire__
-	lea	sp@(-24),sp
-	moveml	d2-d7,sp@	| save d2-d7
-	movel	a0@+,d0
-	movel	a0@+,d1
+	lea	%sp@(-24),%sp
+	moveml	%d2-%d7,%sp@	| save d2-d7
+	movel	%a0@+,%d0
+	movel	%a0@+,%d1
 #else
-	moveml	d2-d7,sp@-	| save d2-d7
-	moveml	a0@+,d0-d1
+	moveml	%d2-%d7,%sp@-	| save d2-d7
+	moveml	%a0@+,%d0-%d1
 #endif
-	movel   a0@,a1		| a1 -> ipart result
+	movel   %a0@,%a1		| a1 -> ipart result
 
-	movel	d0,d2		| calculate exponent
-	swap	d2
+	movel	%d0,%d2		| calculate exponent
+	swap	%d2
 #ifdef __mcoldfire__
-	andil	#0x7fff,d2	| kill sign bit
-	lsrl	#4,d2
+	andil	#0x7fff,%d2	| kill sign bit
+	lsrl	#4,%d2
 #else
-	bclr	#15,d2		| kill sign bit
-	lsrw	#4,d2		| exponent in lower 12 bits of d2
+	bclr	#15,%d2		| kill sign bit
+	lsrw	#4,%d2		| exponent in lower 12 bits of d2
 #endif
 
-	cmpw	#BIAS8,d2
+	cmpw	#BIAS8,%d2
 	jgt	1f		| fabs(value) >= 1.0
 |				| return entire value as fractional part
-	clrl	a1@+		| d0, d1 already ok
-	clrl	a1@		| make integer part 0
+	clrl	%a1@+		| %d0, %d1 already ok
+	clrl	%a1@		| make integer part 0
 
 0:
 #ifdef __mcoldfire__
-	moveml	sp@,d2-d7	| restore saved d2-d7
-	lea	sp@(24),sp
+	moveml	%sp@,%d2-%d7	| restore saved d2-d7
+	lea	%sp@(24),%sp
 #else
-	moveml	sp@+,d2-d7	| restore saved d2-d7
+	moveml	%sp@+,%d2-%d7	| restore saved d2-d7
 #endif
 	rts
 
 1:
 #ifdef __mcoldfire__
-	movel	#BIAS8+53,d3
-	subl	d2,d3		| compute position of "binary point"
+	movel	#BIAS8+53,%d3
+	subl	%d2,%d3		| compute position of "binary point"
 #else
-	movew	#BIAS8+53,d3
-	subw	d2,d3		| compute position of "binary point"
+	movew	#BIAS8+53,%d3
+	subw	%d2,%d3		| compute position of "binary point"
 #endif
 	jgt	2f		| branch if we do have fractional part
 
-	moveml  d0-d1,a1@	| store entire value as the integer part
-	moveq	#0,d0		| return zero as fractional part
-	movel	d0,d1
+	moveml  %d0-%d1,%a1@	| store entire value as the integer part
+	moveq	#0,%d0		| return zero as fractional part
+	movel	%d0,%d1
 	jra	0b
 2:
-	movel	d1,d5		| save for computation of fractional part
+	movel	%d1,%d5		| save for computation of fractional part
 
-	moveq	#32,d6
-	cmpw	d6,d3
+	moveq	#32,%d6
+	cmpw	%d6,%d3
 	jlt	3f		| jump if "binary point" in a lower part
-	movel	d0,d4
+	movel	%d0,%d4
 #ifdef __mcoldfire__
-	subl	d6,d3
+	subl	%d6,%d3
 #else
-	subw	d6,d3
+	subw	%d6,%d3
 #endif
-	moveq	#0,d6		| compute mask for splitting
-	bset	d3,d6
-	negl	d6
-	andl	d6,d0		| this is integer part
-	moveq	#0,d1
-	notl	d6
-	andl	d6,d4		| and denormalized fractional part
+	moveq	#0,%d6		| compute mask for splitting
+	bset	%d3,%d6
+	negl	%d6
+	andl	%d6,%d0		| this is integer part
+	moveq	#0,%d1
+	notl	%d6
+	andl	%d6,%d4		| and denormalized fractional part
 	jra	4f
 3:
-	moveq	#0,d6		| splitting on lower part
-	bset	d3,d6
-	negl	d6
-	andl	d6,d1		| this is integer part
-	moveq	#0,d4		| nothing in an upper fraction
-	notl	d6
-	andl	d6,d5		| and clear those unneded bits
+	moveq	#0,%d6		| splitting on lower part
+	bset	%d3,%d6
+	negl	%d6
+	andl	%d6,%d1		| this is integer part
+	moveq	#0,%d4		| nothing in an upper fraction
+	notl	%d6
+	andl	%d6,%d5		| and clear those unneded bits
 4:
-	moveml	d0-d1,a1@	| store computed integer part
+	moveml	%d0-%d1,%a1@	| store computed integer part
 
-	swap	d0
+	swap	%d0
 #ifdef __mcoldfire__
-	movl	d2,d3		| set registers for norm_df
-	movl	d0,d2
-	movl	d3,d0
+	movl	%d2,%d3		| set registers for norm_df
+	movl	%d0,%d2
+	movl	%d3,%d0
 #else
-	exg	d0,d2		| set registers for norm_df
+	exg	%d0,%d2		| set registers for norm_df
 #endif
-	clrw	d1		| rounding = 0
+	clrw	%d1		| rounding = 0
 |				| normalize fractional part
-	jmp	___norm_df	| norm_df will pop d2/d7 we saved before
+	jmp	C_SYMBOL_NAME(__norm_df)	| norm_df will pop d2/d7 we saved before
 				| it will return to our caller via rts
-				| with result in d0-d1
+				| with result in d0-%d1
 
 #endif	/* __M68881__, sfp004	*/
 #ifdef	__M68881__
@@ -132,16 +135,16 @@ _modf:
 
 	.text; .even
 
-.globl _modf
+.globl C_SYMBOL_NAME(modf)
 
-_modf:
-	fmoved	sp@(4),fp0	| load arg
-	movel	sp@(12),a0	| get pointer to IP
-	fintrzx	fp0,fp1		| get int part
-	fmoved	fp1,a0@		| return it to IP
-	fsubx 	fp1,fp0		| get remainder
-	fmoved	fp0,sp@-	| return it
-	moveml	sp@+,d0-d1	|
+C_SYMBOL_NAME(modf):
+	fmoved	%sp@(4),%fp0	| load arg
+	movel	%sp@(12),%a0	| get pointer to IP
+	fintrzx	%fp0,%fp1		| get int part
+	fmoved	%fp1,%a0@		| return it to IP
+	fsubx 	%fp1,%fp0		| get remainder
+	fmoved	%fp0,%sp@-	| return it
+	moveml	%sp@+,%d0-%d1	|
 	rts
 
 #endif /* __M68881__ */
@@ -153,35 +156,35 @@ zahl =	  0
 
 .even
 .text
-	.globl _modf
+	.globl C_SYMBOL_NAME(modf)
 .even
-_modf:
-	lea	0xfffffa50:w,a0
-	movew	#0x5403,a0@(comm)	| fintrz X -> fp0
-	cmpiw	#0x8900,a0@(resp)	| check
-	movel	a7@(4),a0@		| load X_hi
-	movel	a7@(8),a0@		| load X_low
+C_SYMBOL_NAME(modf):
+	lea	0xfffffa50:w,%a0
+	movew	#0x5403,%a0@(comm)	| fintrz X -> fp0
+	cmpiw	#0x8900,%a0@(resp)	| check
+	movel	%sp@(4),%a0@		| load X_hi
+	movel	%sp@(8),%a0@		| load X_low
 
-	movew	#0x5480,a0@(comm)	| X -> fp1
+	movew	#0x5480,%a0@(comm)	| X -> fp1
 	.long	0x0c688900, 0xfff067f8
-	movel	a7@(4),a0@		| load X_hi
-	movel	a7@(8),a0@		| load X_low
+	movel	%sp@(4),%a0@		| load X_hi
+	movel	%sp@(8),%a0@		| load X_low
 
 |	000 000 001 0101000		| sub fp0 -> fp1
-	movew	#0x00a8,a0@(comm)	| sub fp0 -> fp1
+	movew	#0x00a8,%a0@(comm)	| sub fp0 -> fp1
 	.word	0x4a68,0xfff0,0x6bfa	| test
 
-	movew	#0x7400,a0@(comm)	| fp0 to IntPart
-	moveal	a7@(12),a1		| address of IntPart while the fpu is active
+	movew	#0x7400,%a0@(comm)	| fp0 to IntPart
+	moveal	%sp@(12),%a1		| address of IntPart while the fpu is active
 | wait
 	.long	0x0c688900, 0xfff067f8
-	movel	a0@,a1@+
-	movel	a0@,a1@+
-	movew	#0x7480,a0@(comm)	| Rest to d0/d1
+	movel	%a0@,%a1@+
+	movel	%a0@,%a1@+
+	movew	#0x7480,%a0@(comm)	| Rest to d0/d1
 | wait
 	.long	0x0c688900, 0xfff067f8
-	movel	a0@,d0
-	movel	a0@,d1
+	movel	%a0@,%d0
+	movel	%a0@,%d1
  	rts
 
 #endif	/* sfp004 */

--- a/mintlib/setjmp.S
+++ b/mintlib/setjmp.S
@@ -2,104 +2,106 @@
 | setjmp.S
 |
 
-	.globl ___mint
+#include "libc-symbols.h"
+
+	.globl C_SYMBOL_NAME(__mint)
 
 	.text
 	.even
-	.globl _sigsetjmp
-_sigsetjmp:
-	movel	sp@(4), a0		| address of sigjmp_buf[]
+	.globl C_SYMBOL_NAME(sigsetjmp)
+C_SYMBOL_NAME(sigsetjmp):
+	movel	%sp@(4), %a0		| address of sigjmp_buf[]
 #ifdef __MSHORT__
-	movew	sp@(8), a1
+	movew	%sp@(8), %a1
 #else
-	movel	sp@(8), a1
+	movel	%sp@(8), %a1
 #endif
-	movel	a1, a0@(52)		| save sigmask for siglongjmp?
+	movel	%a1, %a0@(52)		| save sigmask for siglongjmp?
 	jeq	SETJMP			| no -- call common code
-	movel	__sigmask, d0		| save tos emulation signal mask
+	movel	C_SYMBOL_NAME(_sigmask), %d0		| save tos emulation signal mask
 #ifdef __MSHORT__
-	tstw	___mint			| see if MiNT is active
+	tstw	C_SYMBOL_NAME(__mint)			| see if MiNT is active
 #else
-	tstl	___mint
+	tstl	C_SYMBOL_NAME(__mint)
 #endif
 	jeq	nomint			| no -- call common code
 	
-	movel	a0, sp@-		| save register a0
+	movel	%a0, %sp@-		| save register a0
 	
-	clrl	sp@-			| add no signals to sigmask
-	movew	#0x116, sp@-		| Psigblock() system call
+	clrl	%sp@-			| add no signals to sigmask
+	movew	#0x116, %sp@-		| Psigblock() system call
 	trap	#1			|
-	addql	#6, sp
+	addql	#6, %sp
 	
-	movel	sp@+, a0		| restore register a0
+	movel	%sp@+, %a0		| restore register a0
 	
 nomint:
 #ifdef __mcoldfire__
-	orl	#1,d0			| make it != 0 (SIGNULL is unmaskable)
+	orl	#1,%d0			| make it != 0 (SIGNULL is unmaskable)
 #else
-	orw	#1,d0			| make it != 0 (SIGNULL is unmaskable)
+	orw	#1,%d0			| make it != 0 (SIGNULL is unmaskable)
 #endif
-	movel	d0, a0@(52)		| save signal mask
+	movel	%d0, %a0@(52)		| save signal mask
 	jra	SETJMP			| call common code
 
-	.globl _setjmp
-_setjmp:
-	movel	sp@(4),a0		| address of jmp_buf[]
-	clrl	a0@(52)			| do not restore sigmask on longjmp
+	.globl C_SYMBOL_NAME(setjmp)
+C_SYMBOL_NAME(setjmp):
+	movel	%sp@(4),%a0		| address of jmp_buf[]
+	clrl	%a0@(52)			| do not restore sigmask on longjmp
 SETJMP:
-	movel	sp@,a0@			| save return address
-	moveml	d2-d7/a2-a7,a0@(4)	| save registers d2-d7/a2-a7
-	clrl	d0			| return value is 0
+	movel	%sp@,%a0@			| save return address
+	moveml	%d2-%d7/%a2-%a7,%a0@(4)	| save registers d2-d7/a2-a7
+	clrl	%d0			| return value is 0
 	rts
 
-	.globl _siglongjmp
-_siglongjmp:
-	.globl _longjmp
-_longjmp:
+	.globl C_SYMBOL_NAME(siglongjmp)
+C_SYMBOL_NAME(siglongjmp):
+	.globl C_SYMBOL_NAME(longjmp)
+C_SYMBOL_NAME(longjmp):
 #ifdef __MSHORT__
-	tstw	___mint			| see if MiNT is active
+	tstw	C_SYMBOL_NAME(__mint)			| see if MiNT is active
 #else
-	tstl	___mint
+	tstl	C_SYMBOL_NAME(__mint)
 #endif
 	jeq	NOMINT			| no -- do not call sigreturn
-	movew	#0x11a, sp@-		| Psigreturn() system call
+	movew	#0x11a, %sp@-		| Psigreturn() system call
 	trap	#1			| (ignored if not in a sig handler)
-	addql	#2, sp
+	addql	#2, %sp
 NOMINT:
-	movel	sp@(4),a0		| address of jmp_buf[]
-	movel	a0@(52),d0		| want to restore sigmask?
+	movel	%sp@(4),%a0		| address of jmp_buf[]
+	movel	%a0@(52),%d0		| want to restore sigmask?
 	jeq	NORESTORE		| no -- skip restore code
 #ifdef __mcoldfire__
-	andl	#-2,d0
+	andl	#-2,%d0
 #else
-	andw	#-2,d0
+	andw	#-2,%d0
 #endif
-	movel	d0, __sigmask		| restore tos emulation signal mask
+	movel	%d0, C_SYMBOL_NAME(_sigmask)		| restore tos emulation signal mask
 #ifdef __MSHORT__
-	tstw	___mint			| see if MiNT is active
+	tstw	C_SYMBOL_NAME(__mint)			| see if MiNT is active
 #else
-	tstl	___mint
+	tstl	C_SYMBOL_NAME(__mint)
 #endif
 	jeq	NORESTORE		| no -- do not call sigsetmask
 	
-	movel	a0, sp@-		| save register a0
+	movel	%a0, %sp@-		| save register a0
 	
-	movel	d0, sp@-		| restore signal mask
-	movew	#0x117, sp@-		| Psigsetmask() system call
+	movel	%d0, %sp@-		| restore signal mask
+	movew	#0x117, %sp@-		| Psigsetmask() system call
 	trap	#1			|
-	addql	#6, sp
+	addql	#6, %sp
 	
-	movel	sp@+, a0		| restore register a0
+	movel	%sp@+, %a0		| restore register a0
 	
 NORESTORE:
 #ifdef __MSHORT__
-	movew	sp@(8),d0		| value to return
+	movew	%sp@(8),%d0		| value to return
 #else
-	movel	sp@(8),d0		| value to return
+	movel	%sp@(8),%d0		| value to return
 #endif
 	jne	L1			| may not be 0
-	movql	#1, d0
+	movql	#1, %d0
 L1:
-	moveml	a0@(4),d2-d7/a2-a7	| restore saved reggies
-	movl	a0@,sp@			| and the saved return address
+	moveml	%a0@(4),%d2-%d7/%a2-%a7	| restore saved reggies
+	movl	%a0@,%sp@			| and the saved return address
 	rts

--- a/mintlib/setstack.S
+++ b/mintlib/setstack.S
@@ -10,7 +10,7 @@
 
 |
 | _setstack: changes the stack pointer; called as
-|     void setstack( void *newsp )
+|     void _setstack( void *newsp )
 | called from crtinit.c once the new stack size has been decided upon
 |
 | Note: It is strictly forbidden to read or write data at *newsp or beyond.
@@ -27,11 +27,13 @@
 | be accessible!
 | destroys a0 and a7
 
-	.globl	__setstack
-__setstack:
-	movel	sp@+, a0	| save return address
-	movel	sp@, sp		| new stack pointer
-	subl	#64+4, sp	| push some unused space for buggy OS and a
+#include "libc-symbols.h"
+
+	.globl	C_SYMBOL_NAME(_setstack)
+C_SYMBOL_NAME(_setstack):
+	movel	%sp@+, %a0	| save return address
+	movel	%sp@, %sp		| new stack pointer
+	subl	#64+4, %sp	| push some unused space for buggy OS and a
 				| fake parameter to be popped by the caller
-	jmp	a0@		| back to caller
+	jmp	%a0@		| back to caller
 

--- a/startup/Makefile
+++ b/startup/Makefile
@@ -24,7 +24,7 @@ OBJS = crt0.o gcrt0.o
 
 libdir = $(prefix)/lib
 
-INCLUDES = -nostdinc -I$(top_srcdir)/include
+INCLUDES = -nostdinc -I$(top_srcdir)/include -I$(top_srcdir)/mintlib
 
 COMPILE = $(CC) $(WARN) $(CFLAGS) $(INCLUDES) $(DEFS)
 
@@ -33,10 +33,10 @@ all-here: $(OBJS)
 include $(top_srcdir)/phony
 
 crt0.o: $(srcdir)/crt0.S
-	$(COMPILE) -c $< -o $@
+	$(COMPILE) $(INCLUDES) -c $< -o $@
 
 gcrt0.o: $(srcdir)/crt0.S
-	$(COMPILE) -DGCRT0 -c $< -o $@
+	$(COMPILE) $(INCLUDES) -DGCRT0 -c $< -o $@
 
 include $(top_srcdir)/rules
 

--- a/startup/crt0.S
+++ b/startup/crt0.S
@@ -18,28 +18,30 @@
 | .extern in order to ensure they will be linked into the executable
 | even if they are not used in this file.
 
-	.globl	__app		| short, defined in crtinit.c
-	.globl	__base		| BASEPAGE *, defined in globals.c
-	.globl	__heapbase	| void *
-	.globl	__stksize	| long, defined by user or in stksiz.c
-	.globl	_main		| for references
-	.globl	___has_no_ssystem	| int, defined in globals.c
+#include "libc-symbols.h"
+
+	.globl	C_SYMBOL_NAME(_app)		| short, defined in crtinit.c
+	.globl	C_SYMBOL_NAME(_base)		| BASEPAGE *, defined in globals.c
+	.globl	C_SYMBOL_NAME(_heapbase)	| void *
+	.globl	C_SYMBOL_NAME(_stksize)	| long, defined by user or in stksiz.c
+	.globl	C_SYMBOL_NAME(main)		| for references
+	.globl	C_SYMBOL_NAME(__has_no_ssystem)	| int, defined in globals.c
 
 |
 | externs to pull ident strings of all used libraries into the
 | executable; if a library is not used, then the extern is
 | satisfied by a dummy in the library
 
-	.globl	___Ident_gnulib
-	.globl	___Ident_socketlib
-	.globl	___Ident_gem
+	.globl	C_SYMBOL_NAME(__Ident_gnulib)
+	.globl	C_SYMBOL_NAME(__Ident_socketlib)
+	.globl	C_SYMBOL_NAME(__Ident_gem)
 
 |
 | Functions defined elsewhere.
 
-	.extern	__checkcpu	| void _checkcpu(void);
-	.extern	__acc_main	| void _acc_main(void);
-	.extern	__crtinit	| void _crtinit(void);
+	.extern	C_SYMBOL_NAME(_checkcpu)	| void _checkcpu(void);
+	.extern	C_SYMBOL_NAME(_acc_main)	| void _acc_main(void);
+	.extern	C_SYMBOL_NAME(_crtinit)	| void _crtinit(void);
 
 |
 | Assumption: basepage is passed in a0 for accessories; for programs
@@ -47,46 +49,46 @@
 
 	.text
 	.even
-	.globl	__start
-__start:
-	subl	a6, a6		| clear a6 for debuggers
-	cmpl	#0, a0		| test if acc or program
+	.globl	C_SYMBOL_NAME(_start)
+C_SYMBOL_NAME(_start):
+	subl	%a6, %a6		| clear a6 for debuggers
+	cmpl	#0, %a0		| test if acc or program
 	beqs	__startprg	| if a program, go elsewhere
-	tstl	a0@(36)		| also test parent basepage pointer
+	tstl	%a0@(36)		| also test parent basepage pointer
 	bnes	__startprg	| for accs, it must be 0
-	movel	a0, __base	| acc basepage is in A0
-	lea	a0@(252), sp	| use the command line as a temporary stack
+	movel	%a0, C_SYMBOL_NAME(_base)	| acc basepage is in A0
+	lea	%a0@(252), %sp	| use the command line as a temporary stack
 	jsr	.early_init	| early initialization
-	jsr	__checkcpu	| check for correct CPU or exit
-	jmp	__acc_main	| function is in crtinit.c
+	jsr	C_SYMBOL_NAME(_checkcpu)	| check for correct CPU or exit
+	jmp	C_SYMBOL_NAME(_acc_main)	| function is in crtinit.c
 |
 | program startup code: doesn''t actually do much, other than push
 | the basepage onto the stack and call _start1 in crtinit.c
 |
 __startprg:
-	movel	sp@(4), a0	| get basepage
-	movel	a0, __base	| save it
-	movel	a0@(4), d0	| get _base->p_hitpa
-	bclr	#0, d0		| round off
-	movel	d0, sp		| set stack (temporarily)
-	subl	#64, sp		| see note in mintlib/setstack.S
+	movel	%sp@(4), %a0	| get basepage
+	movel	%a0, C_SYMBOL_NAME(_base)	| save it
+	movel	%a0@(4), %d0	| get _base->p_hitpa
+	bclr	#0, %d0		| round off
+	movel	%d0, %sp		| set stack (temporarily)
+	subl	#64, %sp		| see note in mintlib/setstack.S
 	jsr	.early_init	| early initialization
-	jsr	__checkcpu	| check for correct CPU or exit
-	jmp	__crtinit	| in crtinit.c
+	jsr	C_SYMBOL_NAME(_checkcpu)	| check for correct CPU or exit
+	jmp	C_SYMBOL_NAME(_crtinit)	| in crtinit.c
 
 |
 | Initialize global variables required by early initialization code.
 | Warning: The registers are not preserved
 |
 .early_init:
-	clrl	sp@-
-	clrl	sp@-
-	movew	#-1,sp@-	| Check Ssystem() availability
-	movew	#0x154,sp@-	| Ssystem()
+	clrl	%sp@-
+	clrl	%sp@-
+	movew	#-1,%sp@-	| Check Ssystem() availability
+	movew	#0x154,%sp@-	| Ssystem()
 	trap	#1
-	lea	sp@(12),sp
+	lea	%sp@(12),%sp
 
-	movel	d0,___has_no_ssystem
+	movel	%d0,C_SYMBOL_NAME(__has_no_ssystem)
 
 	rts
 
@@ -94,24 +96,24 @@ __startprg:
 | interfaces for gprof: for crt0.o, does nothing, but for gcrt0.o branches
 | to the appropriate subroutines
 |
-	.globl 	__monstartup
-	.globl	__moncontrol
-	.globl 	___mcleanup
+	.globl 	C_SYMBOL_NAME(_monstartup)
+	.globl	C_SYMBOL_NAME(_moncontrol)
+	.globl 	C_SYMBOL_NAME(__mcleanup)
 
 #ifdef GCRT0
-	.extern	_monstartup
-	.extern	_moncontrol
-	.extern	__mcleanup
+	.extern	C_SYMBOL_NAME(monstartup)
+	.extern	C_SYMBOL_NAME(moncontrol)
+	.extern	C_SYMBOL_NAME(_mcleanup)
 
-__monstartup:
-	jmp	_monstartup
-__moncontrol:
-	jmp	_moncontrol
-___mcleanup:
-	jmp	__mcleanup
+C_SYMBOL_NAME(_monstartup):
+	jmp	C_SYMBOL_NAME(monstartup)
+C_SYMBOL_NAME(_moncontrol):
+	jmp	C_SYMBOL_NAME(moncontrol)
+C_SYMBOL_NAME(__mcleanup):
+	jmp	C_SYMBOL_NAME(_mcleanup)
 #else
-__monstartup:
-__moncontrol:
-___mcleanup:
+C_SYMBOL_NAME(_monstartup):
+C_SYMBOL_NAME(_moncontrol):
+C_SYMBOL_NAME(__mcleanup):
 	rts
 #endif /* GCRT0 */

--- a/stdlib/alloca.S
+++ b/stdlib/alloca.S
@@ -4,33 +4,33 @@
 |  void *alloca(size_t size)
 | 
 
-#include <libc-symbols.h>
+#include "libc-symbols.h"
 
 	.text
  	.even
 
-	.globl	___alloca
+	.globl	C_SYMBOL_NAME(__alloca)
 	weak_alias (__alloca, alloca)
 	
-___alloca:
-	movel	sp@+,a0		| get return addr
+C_SYMBOL_NAME(__alloca):
+	movel	%sp@+,%a0		| get return addr
 #ifndef __SOZOBON__
-	movel	sp@+,d0		| get size -- assist in bug fix, add 4 to sp
+	movel	%sp@+,%d0		| get size -- assist in bug fix, add 4 to sp
 #else
-	clrl	d0		| this size_t thing is getting to be
-	movew	sp@+,d0		|  an annoyance...  -- sb
+	clrl	%d0		| this size_t thing is getting to be
+	movew	%sp@+,%d0		|  an annoyance...  -- sb
 #endif
 
-	addql	#1,d0		| ensure address even
-	bclr	#0,d0		| lop off odd bit
+	addql	#1,%d0		| ensure address even
+	bclr	#0,%d0		| lop off odd bit
 
-	subl	d0,sp		| increase stack frame size by that much
-	movel	sp,d0		| set up to return it
+	subl	%d0,%sp		| increase stack frame size by that much
+	movel	%sp,%d0		| set up to return it
 
 #ifndef __SOZOBON__
-	lea	sp@(-4),sp	| new top of stack (real bug fix here)
+	lea	%sp@(-4),%sp	| new top of stack (real bug fix here)
 #else
-	lea	sp@(-2),sp	| hope this is correct...  -- sb
+	lea	%sp@(-2),%sp	| hope this is correct...  -- sb
 #endif
 
-	jmp	a0@		| return by jmping via saved addr
+	jmp	%a0@		| return by jmping via saved addr

--- a/string/bcopy.S
+++ b/string/bcopy.S
@@ -5,13 +5,15 @@
 |	Alexander Lehmann	alexlehm@iti.informatik.th-darmstadt.de
 |	sortof inspired by jrbs bcopy
 
+#include "libc-symbols.h"
+
 	.text
 	.even
-	.globl ___bcopy
-	.globl __bcopy
-	.globl _bcopy
-	.globl _memcpy
-	.globl _memmove
+	.globl C_SYMBOL_NAME(__bcopy)
+	.globl C_SYMBOL_NAME(_bcopy)
+	.globl C_SYMBOL_NAME(bcopy)
+	.globl C_SYMBOL_NAME(memcpy)
+	.globl C_SYMBOL_NAME(memmove)
 
 |	void *memcpy( void *dest, const void *src, size_t len );
 |	void *memmove( void *dest, const void *src, size_t len );
@@ -19,28 +21,28 @@
 |	functions are aliased
 
 #ifndef __SOZOBON__
-_memcpy:
-_memmove:
-	movl	sp@(4),a1	| dest
-	movl	sp@(8),a0	| src
+C_SYMBOL_NAME(memcpy):
+C_SYMBOL_NAME(memmove):
+	movl	%sp@(4),%a1	| dest
+	movl	%sp@(8),%a0	| src
 	jra	common		| the rest is samea as bcopy
 #else
 |	___bcopy() is the base function below; for memcpy(), memmove()
 |	and bcopy(), we have to sneak a size_t into an unsigned long first.
 
-_memcpy:
-_memmove:
-	movl	sp@(4),a1	| dest
-	movl	sp@(8),a0	| src
-	clrl	d0		| here is the sneaky bit...
-	movw	sp@(12),d0	| length
+C_SYMBOL_NAME(memcpy):
+C_SYMBOL_NAME(memmove):
+	movl	%sp@(4),%a1	| dest
+	movl	%sp@(8),%a0	| src
+	clrl	%d0		| here is the sneaky bit...
+	movw	%sp@(12),%d0	| length
 	jra	common2		| the rest is samea as bcopy
 
-_bcopy:
-	movl	sp@(4),a0	| src
-	movl	sp@(8),a1	| dest
-	clrl	d0		| here is the sneaky bit...
-	movw	sp@(12),d0	| length
+C_SYMBOL_NAME(bcopy):
+	movl	%sp@(4),%a0	| src
+	movl	%sp@(8),%a1	| dest
+	clrl	%d0		| here is the sneaky bit...
+	movw	%sp@(12),%d0	| length
 	jra	common2		| the rest is samea as bcopy
 #endif
 
@@ -50,303 +52,303 @@ _bcopy:
 |	functions are aliased (except for HSC -- sb)
 
 #ifndef __SOZOBON__
-_bcopy:
-___bcopy:
+C_SYMBOL_NAME(bcopy):
+C_SYMBOL_NAME(__bcopy):
 #endif
-__bcopy:
-	movl	sp@(4),a0	| src
-	movl	sp@(8),a1	| dest
-common:	movl	sp@(12),d0	| length
+C_SYMBOL_NAME(_bcopy):
+	movl	%sp@(4),%a0	| src
+	movl	%sp@(8),%a1	| dest
+common:	movl	%sp@(12),%d0	| length
 common2:
 	jeq	exit		| length==0? (size_t)
 
 				| a0 src, a1 dest, d0.l length
-	movel	d2,sp@-
+	movel	%d2,%sp@-
 
 	| overlay ?
-	cmpl	a0,a1
+	cmpl	%a0,%a1
 	jgt	top_down
 
 #ifdef __mcoldfire__
-	movl	a0,d1		| test for alignment
-	movl	a1,d2
-	eorl	d2,d1
+	movl	%a0,%d1		| test for alignment
+	movl	%a1,%d2
+	eorl	%d2,%d1
 #else
-	movw	a0,d1		| test for alignment
-	movw	a1,d2
-	eorw	d2,d1
+	movw	%a0,%d1		| test for alignment
+	movw	%a1,%d2
+	eorw	%d2,%d1
 #endif
-	btst	#0,d1		| one odd one even ?
+	btst	#0,%d1		| one odd one even ?
 	jne	slow_copy
-	btst	#0,d2		| both even ?
+	btst	#0,%d2		| both even ?
 	jeq	both_even
-	movb	a0@+,a1@+	| copy one byte, now we are both even
-	subql	#1,d0
+	movb	%a0@+,%a1@+	| copy one byte, now we are both even
+	subql	#1,%d0
 both_even:
-	movq	#0,d1		| save length less 256
-	movb	d0,d1
-	lsrl	#8,d0		| number of 256 bytes blocks
+	movq	#0,%d1		| save length less 256
+	movb	%d0,%d1
+	lsrl	#8,%d0		| number of 256 bytes blocks
 	jeq	less256
 #ifdef __mcoldfire__
-	lea	sp@(-40),sp
-	movml	d1/d3-d7/a2/a3/a5/a6,sp@	| d2 is already saved
+	lea	%sp@(-40),%sp
+	movml	%d1/%d3-%d7/%a2/%a3/%a5/%a6,%sp@	| d2 is already saved
 					| exclude a4 because of -mbaserel
 copy256:
-	movml	a0@,d1-d7/a2/a3/a5/a6	| copy 5*44+36=256 bytes
-	movml	d1-d7/a2/a3/a5/a6,a1@
-	movml	a0@(44),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(44)
-	movml	a0@(88),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(88)
-	movml	a0@(132),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(132)
-	movml	a0@(176),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(176)
-	movml	a0@(220),d1-d7/a2-a3
-	movml	d1-d7/a2-a3,a1@(220)
-	lea	a0@(256),a0
+	movml	%a0@,%d1-%d7/%a2/%a3/%a5/%a6	| copy 5*44+36=256 bytes
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@
+	movml	%a0@(44),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(44)
+	movml	%a0@(88),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(88)
+	movml	%a0@(132),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(132)
+	movml	%a0@(176),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(176)
+	movml	%a0@(220),%d1-%d7/%a2-%a3
+	movml	%d1-%d7/%a2-%a3,%a1@(220)
+	lea	%a0@(256),%a0
 #else
-	movml	d1/d3-d7/a2/a3/a5/a6,sp@-	| d2 is already saved
+	movml	%d1/%d3-%d7/%a2/%a3/%a5/%a6,%sp@-	| d2 is already saved
 					| exclude a4 because of -mbaserel
 copy256:
-	movml	a0@+,d1-d7/a2/a3/a5/a6	| copy 5*44+36=256 bytes
-	movml	d1-d7/a2/a3/a5/a6,a1@
-	movml	a0@+,d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(44)
-	movml	a0@+,d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(88)
-	movml	a0@+,d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(132)
-	movml	a0@+,d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(176)
-	movml	a0@+,d1-d7/a2-a3
-	movml	d1-d7/a2-a3,a1@(220)
+	movml	%a0@+,%d1-%d7/%a2/%a3/%a5/%a6	| copy 5*44+36=256 bytes
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@
+	movml	%a0@+,%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(44)
+	movml	%a0@+,%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(88)
+	movml	%a0@+,%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(132)
+	movml	%a0@+,%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(176)
+	movml	%a0@+,%d1-%d7/%a2-%a3
+	movml	%d1-%d7/%a2-%a3,%a1@(220)
 #endif
-	lea	a1@(256),a1		| increment dest, src is already
-	subql	#1,d0
+	lea	%a1@(256),%a1		| increment dest, src is already
+	subql	#1,%d0
 	jne	copy256 		| next, please
 #ifdef __mcoldfire__
-	movml	sp@,d1/d3-d7/a2/a3/a5/a6
-	lea	sp@(40),sp
+	movml	%sp@,%d1/%d3-%d7/%a2/%a3/%a5/%a6
+	lea	%sp@(40),%sp
 less256:			| copy 16 bytes blocks
-	movl	d1,d0
-	lsrl	#2,d0		| number of 4 bytes blocks
+	movl	%d1,%d0
+	lsrl	#2,%d0		| number of 4 bytes blocks
 	jeq	less4		| less that 4 bytes left
-	movl	d0,d2
-	negl	d2
-	andil	#3,d2		| d2 = number of bytes below 16 (-n)&3
-	subql	#1,d0
-	lsrl	#2,d0		| number of 16 bytes blocks minus 1, if d2==0
-	addl	d2,d2		| offset in code (movl two bytes)
-	jmp	pc@(2,d2:l)	| jmp into loop
+	movl	%d0,%d2
+	negl	%d2
+	andil	#3,%d2		| d2 = number of bytes below 16 (-n)&3
+	subql	#1,%d0
+	lsrl	#2,%d0		| number of 16 bytes blocks minus 1, if d2==0
+	addl	%d2,%d2		| offset in code (movl two bytes)
+	jmp	%pc@(2,%d2:l)	| jmp into loop
 #else
-	movml	sp@+,d1/d3-d7/a2/a3/a5/a6
+	movml	%sp@+,%d1/%d3-%d7/%a2/%a3/%a5/%a6
 less256:			| copy 16 bytes blocks
-	movw	d1,d0
-	lsrw	#2,d0		| number of 4 bytes blocks
+	movw	%d1,%d0
+	lsrw	#2,%d0		| number of 4 bytes blocks
 	jeq	less4		| less that 4 bytes left
-	movw	d0,d2
-	negw	d2
-	andiw	#3,d2		| d2 = number of bytes below 16 (-n)&3
-	subqw	#1,d0
-	lsrw	#2,d0		| number of 16 bytes blocks minus 1, if d2==0
-	addw	d2,d2		| offset in code (movl two bytes)
-	jmp	pc@(2,d2:w)	| jmp into loop
+	movw	%d0,%d2
+	negw	%d2
+	andiw	#3,%d2		| d2 = number of bytes below 16 (-n)&3
+	subqw	#1,%d0
+	lsrw	#2,%d0		| number of 16 bytes blocks minus 1, if d2==0
+	addw	%d2,%d2		| offset in code (movl two bytes)
+	jmp	%pc@(2,%d2:w)	| jmp into loop
 #endif
 copy16:
-	movl	a0@+,a1@+
-	movl	a0@+,a1@+
-	movl	a0@+,a1@+
-	movl	a0@+,a1@+
+	movl	%a0@+,%a1@+
+	movl	%a0@+,%a1@+
+	movl	%a0@+,%a1@+
+	movl	%a0@+,%a1@+
 #ifdef __mcoldfire__
-	subql	#1,d0
+	subql	#1,%d0
 	bpl	copy16
 #else
-	dbra	d0,copy16
+	dbra	%d0,copy16
 #endif
 less4:
-	btst	#1,d1
+	btst	#1,%d1
 	jeq	less2
-	movw	a0@+,a1@+
+	movw	%a0@+,%a1@+
 less2:
-	btst	#0,d1
+	btst	#0,%d1
 	jeq	none
-	movb	a0@,a1@
+	movb	%a0@,%a1@
 none:
 exit_d2:
-	movl	sp@+,d2
+	movl	%sp@+,%d2
 exit:
-	movl sp@(4),d0		| return dest (for memcpy only)
+	movl %sp@(4),%d0		| return dest (for memcpy only)
 	rts
 
 slow_copy:			| byte by bytes copy
 #ifdef __mcoldfire__
-	movl	d0,d1
-	negl	d1
-	andil	#7,d1		| d1 = number of bytes blow 8 (-n)&7
-	addql	#7,d0
-	lsrl	#3,d0		| number of 8 bytes block plus 1, if d1!=0
-	addl	d1,d1		| offset in code (movb two bytes)
-	jmp	pc@(2,d1:l)	| jump into loop
+	movl	%d0,%d1
+	negl	%d1
+	andil	#7,%d1		| d1 = number of bytes blow 8 (-n)&7
+	addql	#7,%d0
+	lsrl	#3,%d0		| number of 8 bytes block plus 1, if d1!=0
+	addl	%d1,%d1		| offset in code (movb two bytes)
+	jmp	%pc@(2,%d1:l)	| jump into loop
 #else
-	movw	d0,d1
-	negw	d1
-	andiw	#7,d1		| d1 = number of bytes blow 8 (-n)&7
-	addql	#7,d0
-	lsrl	#3,d0		| number of 8 bytes block plus 1, if d1!=0
-	addw	d1,d1		| offset in code (movb two bytes)
-	jmp	pc@(2,d1:w)	| jump into loop
+	movw	%d0,%d1
+	negw	%d1
+	andiw	#7,%d1		| d1 = number of bytes blow 8 (-n)&7
+	addql	#7,%d0
+	lsrl	#3,%d0		| number of 8 bytes block plus 1, if d1!=0
+	addw	%d1,%d1		| offset in code (movb two bytes)
+	jmp	%pc@(2,%d1:w)	| jump into loop
 #endif
 scopy:
-	movb	a0@+,a1@+
-	movb	a0@+,a1@+
-	movb	a0@+,a1@+
-	movb	a0@+,a1@+
-	movb	a0@+,a1@+
-	movb	a0@+,a1@+
-	movb	a0@+,a1@+
-	movb	a0@+,a1@+
-	subql	#1,d0
+	movb	%a0@+,%a1@+
+	movb	%a0@+,%a1@+
+	movb	%a0@+,%a1@+
+	movb	%a0@+,%a1@+
+	movb	%a0@+,%a1@+
+	movb	%a0@+,%a1@+
+	movb	%a0@+,%a1@+
+	movb	%a0@+,%a1@+
+	subql	#1,%d0
 	jne	scopy
 	jra	exit_d2
 
 top_down:
-	addl	d0,a0		| a0 byte after end of src
-	addl	d0,a1		| a1 byte after end of dest
+	addl	%d0,%a0		| a0 byte after end of src
+	addl	%d0,%a1		| a1 byte after end of dest
 
 #ifdef __mcoldfire__
-	movl	a0,d1		| exact the same as above, only with predec
-	movl	a1,d2
-	eorl	d2,d1
+	movl	%a0,%d1		| exact the same as above, only with predec
+	movl	%a1,%d2
+	eorl	%d2,%d1
 #else
-	movw	a0,d1		| exact the same as above, only with predec
-	movw	a1,d2
-	eorw	d2,d1
+	movw	%a0,%d1		| exact the same as above, only with predec
+	movw	%a1,%d2
+	eorw	%d2,%d1
 #endif
-	btst	#0,d1
+	btst	#0,%d1
 	jne	slow_copy_d
 
-	btst	#0,d2
+	btst	#0,%d2
 	jeq	both_even_d
-	movb	a0@-,a1@-
-	subql	#1,d0
+	movb	%a0@-,%a1@-
+	subql	#1,%d0
 both_even_d:
-	movq	#0,d1
-	movb	d0,d1
-	lsrl	#8,d0
+	movq	#0,%d1
+	movb	%d0,%d1
+	lsrl	#8,%d0
 	jeq	less256_d
 #ifdef __mcoldfire__
-	lea	sp@(-40),sp
-	movml	d1/d3-d7/a2/a3/a5/a6,sp@
+	lea	%sp@(-40),%sp
+	movml	%d1/%d3-%d7/%a2/%a3/%a5/%a6,%sp@
 copy256_d:
-	movml	a0@(-44),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(-44)
-	movml	a0@(-88),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(-88)
-	movml	a0@(-132),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(-132)
-	movml	a0@(-176),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(-176)
-	movml	a0@(-220),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@(-220)
-	movml	a0@(-256),d1-d7/a2-a3
-	movml	d1-d7/a2-a3,a1@(-256)
-	lea	a1@(-256),a1
+	movml	%a0@(-44),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(-44)
+	movml	%a0@(-88),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(-88)
+	movml	%a0@(-132),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(-132)
+	movml	%a0@(-176),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(-176)
+	movml	%a0@(-220),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@(-220)
+	movml	%a0@(-256),%d1-%d7/%a2-%a3
+	movml	%d1-%d7/%a2-%a3,%a1@(-256)
+	lea	%a1@(-256),%a1
 #else
-	movml	d1/d3-d7/a2/a3/a5/a6,sp@-
+	movml	%d1/%d3-%d7/%a2/%a3/%a5/%a6,%sp@-
 copy256_d:
-	movml	a0@(-44),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@-
-	movml	a0@(-88),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@-
-	movml	a0@(-132),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@-
-	movml	a0@(-176),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@-
-	movml	a0@(-220),d1-d7/a2/a3/a5/a6
-	movml	d1-d7/a2/a3/a5/a6,a1@-
-	movml	a0@(-256),d1-d7/a2-a3
-	movml	d1-d7/a2-a3,a1@-
+	movml	%a0@(-44),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@-
+	movml	%a0@(-88),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@-
+	movml	%a0@(-132),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@-
+	movml	%a0@(-176),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@-
+	movml	%a0@(-220),%d1-%d7/%a2/%a3/%a5/%a6
+	movml	%d1-%d7/%a2/%a3/%a5/%a6,%a1@-
+	movml	%a0@(-256),%d1-%d7/%a2-%a3
+	movml	%d1-%d7/%a2-%a3,%a1@-
 #endif
-	lea	a0@(-256),a0
-	subql	#1,d0
+	lea	%a0@(-256),%a0
+	subql	#1,%d0
 	jne	copy256_d
 #ifdef __mcoldfire__
-	movml	sp@,d1/d3-d7/a2/a3/a5/a6
-	lea	sp@(40),sp
+	movml	%sp@,%d1/%d3-%d7/%a2/%a3/%a5/%a6
+	lea	%sp@(40),%sp
 less256_d:
-	movl	d1,d0
-	lsrl	#2,d0
+	movl	%d1,%d0
+	lsrl	#2,%d0
 	jeq	less4_d
-	movl	d0,d2
-	negl	d2
-	andil	#3,d2
-	subql	#1,d0
-	lsrl	#2,d0
-	addl	d2,d2
-	jmp	pc@(2,d2:l)
+	movl	%d0,%d2
+	negl	%d2
+	andil	#3,%d2
+	subql	#1,%d0
+	lsrl	#2,%d0
+	addl	%d2,%d2
+	jmp	%pc@(2,%d2:l)
 #else
-	movml	sp@+,d1/d3-d7/a2/a3/a5/a6
+	movml	%sp@+,%d1/%d3-%d7/%a2/%a3/%a5/%a6
 less256_d:
-	movw	d1,d0
-	lsrw	#2,d0
+	movw	%d1,%d0
+	lsrw	#2,%d0
 	jeq	less4_d
-	movw	d0,d2
-	negw	d2
-	andiw	#3,d2
-	subqw	#1,d0
-	lsrw	#2,d0
-	addw	d2,d2
-	jmp	pc@(2,d2:w)
+	movw	%d0,%d2
+	negw	%d2
+	andiw	#3,%d2
+	subqw	#1,%d0
+	lsrw	#2,%d0
+	addw	%d2,%d2
+	jmp	%pc@(2,%d2:w)
 #endif
 copy16_d:
-	movl	a0@-,a1@-
-	movl	a0@-,a1@-
-	movl	a0@-,a1@-
-	movl	a0@-,a1@-
+	movl	%a0@-,%a1@-
+	movl	%a0@-,%a1@-
+	movl	%a0@-,%a1@-
+	movl	%a0@-,%a1@-
 #ifdef __mcoldfire__
-	subql	#1,d0
+	subql	#1,%d0
 	bpl	copy16_d
 #else
-	dbra	d0,copy16_d
+	dbra	%d0,copy16_d
 #endif
 less4_d:
-	btst	#1,d1
+	btst	#1,%d1
 	jeq	less2_d
-	movw	a0@-,a1@-
+	movw	%a0@-,%a1@-
 less2_d:
-	btst	#0,d1
+	btst	#0,%d1
 	jeq	exit_d2
-	movb	a0@-,a1@-
+	movb	%a0@-,%a1@-
 	jra	exit_d2
 slow_copy_d:
 #ifdef __mcoldfire__
-	movl	d0,d1
-	negl	d1
-	andil	#7,d1
-	addql	#7,d0
-	lsrl	#3,d0
-	addl	d1,d1
-	jmp	pc@(2,d1:l)
+	movl	%d0,%d1
+	negl	%d1
+	andil	#7,%d1
+	addql	#7,%d0
+	lsrl	#3,%d0
+	addl	%d1,%d1
+	jmp	%pc@(2,%d1:l)
 #else
-	movw	d0,d1
-	negw	d1
-	andiw	#7,d1
-	addql	#7,d0
-	lsrl	#3,d0
-	addw	d1,d1
-	jmp	pc@(2,d1:w)
+	movw	%d0,%d1
+	negw	%d1
+	andiw	#7,%d1
+	addql	#7,%d0
+	lsrl	#3,%d0
+	addw	%d1,%d1
+	jmp	%pc@(2,%d1:w)
 #endif
 scopy_d:
-	movb	a0@-,a1@-
-	movb	a0@-,a1@-
-	movb	a0@-,a1@-
-	movb	a0@-,a1@-
-	movb	a0@-,a1@-
-	movb	a0@-,a1@-
-	movb	a0@-,a1@-
-	movb	a0@-,a1@-
-	subql	#1,d0
+	movb	%a0@-,%a1@-
+	movb	%a0@-,%a1@-
+	movb	%a0@-,%a1@-
+	movb	%a0@-,%a1@-
+	movb	%a0@-,%a1@-
+	movb	%a0@-,%a1@-
+	movb	%a0@-,%a1@-
+	movb	%a0@-,%a1@-
+	subql	#1,%d0
 	jne	scopy_d
 	jra	exit_d2
 

--- a/string/bzero.S
+++ b/string/bzero.S
@@ -7,26 +7,28 @@
 	.text
 	.even
 
+#include "libc-symbols.h"
+
 #ifdef Lmemset
-	.globl _memset
+	.globl C_SYMBOL_NAME(memset)
 
 |	void *memset( void *dest, int val, size_t len );
 |	returns dest
 |	two versions for 16/32 bits
 
-_memset:
-	movl	sp@(4),a0	| dest
+C_SYMBOL_NAME(memset):
+	movl	%sp@(4),%a0	| dest
 #ifdef __MSHORT__
-	movb	sp@(9),d0	| value
+	movb	%sp@(9),%d0	| value
 # ifndef __SOZOBON__
-	movl	sp@(10),d1	| length
+	movl	%sp@(10),%d1	| length
 # else
-	clrl	d1
-	movw	sp@(10),d1	| length
+	clrl	%d1
+	movw	%sp@(10),%d1	| length
 # endif
 #else
-	movb	sp@(11),d0	| value
-	movl	sp@(12),d1	| length
+	movb	%sp@(11),%d0	| value
+	movl	%sp@(12),%d1	| length
 #endif
 	jeq	exit		| length==0? (size_t)
 #ifndef Lmemset
@@ -35,148 +37,148 @@ _memset:
 #endif /* Lmemset */
 
 #ifndef Lmemset
-	.globl _bzero
-	.globl __bzero
-	.globl ___bzero
+	.globl C_SYMBOL_NAME(bzero)
+	.globl C_SYMBOL_NAME(_bzero)
+	.globl C_SYMBOL_NAME(__bzero)
 
 |	void bzero( void *dest, size_t length );
 |	void _bzero( void *dest, unsigned long length );
 |	return value not used (returns dest)
 
 #ifdef __SOZOBON__
-___bzero:
-_bzero:
-	movl	sp@(4),a0	| dest
-	clrl	d1
-	movw	sp@(8),d1	| length
+C_SYMBOL_NAME(__bzero):
+C_SYMBOL_NAME(bzero):
+	movl	%sp@(4),%a0	| dest
+	clrl	%d1
+	movw	%sp@(8),%d1	| length
 	jra	scommon
 #else
-___bzero:
-_bzero:
+C_SYMBOL_NAME(__bzero):
+C_SYMBOL_NAME(bzero):
 #endif
-__bzero:
-	movl	sp@(4),a0	| dest
-	movl	sp@(8),d1	| length
+C_SYMBOL_NAME(_bzero):
+	movl	%sp@(4),%a0	| dest
+	movl	%sp@(8),%d1	| length
 scommon:
 	jeq	exit		| length==0? (size_t)
-	clrb	d0		| value
+	clrb	%d0		| value
 #endif /* Lbzero */
 
 do_set: 			| a0 dest, d0.b byte, d1.l length
-	movel	d2,sp@-
+	movel	%d2,%sp@-
 
-	addl	d1,a0		| a0 points to end of area, needed for predec
+	addl	%d1,%a0		| a0 points to end of area, needed for predec
 
-	movw	a0,d2		| test for alignment
-	btst	#0,d2		| odd ?
+	movw	%a0,%d2		| test for alignment
+	btst	#0,%d2		| odd ?
 	jeq	areeven
-	movb	d0,a0@- 	| set one byte, now we are even
-	subql	#1,d1
+	movb	%d0,%a0@- 	| set one byte, now we are even
+	subql	#1,%d1
 areeven:
-	movb	d0,d2
+	movb	%d0,%d2
 #ifdef __mcoldfire__
-	lsll	#8,d0
+	lsll	#8,%d0
 #else
-	lslw	#8,d0
+	lslw	#8,%d0
 #endif
-	movb	d2,d0
-	movw	d0,d2
-	swap	d2
-	movw	d0,d2		| d2 has byte now four times
+	movb	%d2,%d0
+	movw	%d0,%d2
+	swap	%d2
+	movw	%d0,%d2		| d2 has byte now four times
 
-	movq	#0,d0		| save length less 256
-	movb	d1,d0
-	lsrl	#8,d1		| number of 256 bytes blocks
+	movq	#0,%d0		| save length less 256
+	movb	%d1,%d0
+	lsrl	#8,%d1		| number of 256 bytes blocks
 	jeq	less256
 #ifdef __mcoldfire__
-	lea	sp@(-40),sp
-	movml	d0/d3-d7/a2/a3/a5/a6,sp@	| d2 is already saved
+	lea	%sp@(-40),%sp
+	movml	%d0/%d3-%d7/%a2/%a3/%a5/%a6,%sp@	| d2 is already saved
 #else
-	movml	d0/d3-d7/a2/a3/a5/a6,sp@-	| d2 is already saved
+	movml	%d0/%d3-%d7/%a2/%a3/%a5/%a6,%sp@-	| d2 is already saved
 #endif
 				| exclude a4 because of -mbaserel
-	movl	d2,d0
-	movl	d2,d3
-	movl	d2,d4
-	movl	d2,d5
-	movl	d2,d6
-	movl	d2,d7
-	movl	d2,a2
-	movl	d2,a3
-	movl	d2,a5
-	movl	d2,a6
+	movl	%d2,%d0
+	movl	%d2,%d3
+	movl	%d2,%d4
+	movl	%d2,%d5
+	movl	%d2,%d6
+	movl	%d2,%d7
+	movl	%d2,%a2
+	movl	%d2,%a3
+	movl	%d2,%a5
+	movl	%d2,%a6
 set256:
 #ifdef __mcoldfire__
-	lea	a0@(-256),a0
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@(212)	| set 5*44+36=256 bytes
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@(168)
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@(124)
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@(80)
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@(36)
-	movml	d0/d2-d7/a2-a3,a0@
+	lea	%a0@(-256),%a0
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@(212)	| set 5*44+36=256 bytes
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@(168)
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@(124)
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@(80)
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@(36)
+	movml	%d0/%d2-%d7/%a2-%a3,%a0@
 #else
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@-	| set 5*44+36=256 bytes
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@-
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@-
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@-
-	movml	d0/d2-d7/a2/a3/a5/a6,a0@-
-	movml	d0/d2-d7/a2-a3,a0@-
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@-	| set 5*44+36=256 bytes
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@-
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@-
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@-
+	movml	%d0/%d2-%d7/%a2/%a3/%a5/%a6,%a0@-
+	movml	%d0/%d2-%d7/%a2-%a3,%a0@-
 #endif
-	subql	#1,d1
+	subql	#1,%d1
 	jne	set256			| next, please
 #ifdef __mcoldfire__
-	movml	sp@,d0/d3-d7/a2/a3/a5/a6
-	lea	sp@(40),sp
+	movml	%sp@,%d0/%d3-%d7/%a2/%a3/%a5/%a6
+	lea	%sp@(40),%sp
 #else
-	movml	sp@+,d0/d3-d7/a2/a3/a5/a6
+	movml	%sp@+,%d0/%d3-%d7/%a2/%a3/%a5/%a6
 #endif
 less256:			| set 16 bytes blocks
-	movw	d0,sp@- 	| save length below 256 for last 3 bytes
+	movw	%d0,%sp@- 	| save length below 256 for last 3 bytes
 #ifdef __mcoldfire__
-	lsrl	#2,d0
+	lsrl	#2,%d0
 	jeq	less4		| less that 4 bytes left
-	movl	d0,d1
-	negl	d1
-	andil	#3,d1		| d1 = number of bytes below 16 (-n)&3
-	subql	#1,d0
-	lsrl	#2,d0		| number of 16 bytes blocks minus 1, if d1==0
-	addl	d1,d1		| offset in code (movl two bytes)
-	jmp	pc@(2,d1:l)	| jmp into loop
+	movl	%d0,%d1
+	negl	%d1
+	andil	#3,%d1		| d1 = number of bytes below 16 (-n)&3
+	subql	#1,%d0
+	lsrl	#2,%d0		| number of 16 bytes blocks minus 1, if d1==0
+	addl	%d1,%d1		| offset in code (movl two bytes)
+	jmp	%pc@(2,%d1:l)	| jmp into loop
 #else
-	lsrw	#2,d0		| number of 4 bytes blocks
+	lsrw	#2,%d0		| number of 4 bytes blocks
 	jeq	less4		| less that 4 bytes left
-	movw	d0,d1
-	negw	d1
-	andiw	#3,d1		| d1 = number of bytes below 16 (-n)&3
-	subqw	#1,d0
-	lsrw	#2,d0		| number of 16 bytes blocks minus 1, if d1==0
-	addw	d1,d1		| offset in code (movl two bytes)
-	jmp	pc@(2,d1:w)	| jmp into loop
+	movw	%d0,%d1
+	negw	%d1
+	andiw	#3,%d1		| d1 = number of bytes below 16 (-n)&3
+	subqw	#1,%d0
+	lsrw	#2,%d0		| number of 16 bytes blocks minus 1, if d1==0
+	addw	%d1,%d1		| offset in code (movl two bytes)
+	jmp	%pc@(2,%d1:w)	| jmp into loop
 #endif
 set16:
-	movl	d2,a0@-
-	movl	d2,a0@-
-	movl	d2,a0@-
-	movl	d2,a0@-
+	movl	%d2,%a0@-
+	movl	%d2,%a0@-
+	movl	%d2,%a0@-
+	movl	%d2,%a0@-
 #ifdef __mcoldfire__
-	subql	#1,d0
+	subql	#1,%d0
 	bpl	set16
 #else
-	dbra	d0,set16
+	dbra	%d0,set16
 #endif
 less4:
-	movw	sp@+,d0
-	btst	#1,d0
+	movw	%sp@+,%d0
+	btst	#1,%d0
 	jeq	less2
-	movw	d2,a0@-
+	movw	%d2,%a0@-
 less2:
-	btst	#0,d0
+	btst	#0,%d0
 	jeq	none
-	movb	d2,a0@-
+	movb	%d2,%a0@-
 none:
 exit_d2:
-	movl	sp@+,d2
+	movl	%sp@+,%d2
 exit:
-	movl sp@(4),d0		| return dest (for memset only)
+	movl %sp@(4),%d0		| return dest (for memset only)
 	rts
 

--- a/syscall/traps.c
+++ b/syscall/traps.c
@@ -183,20 +183,20 @@ generate_trap_impl(FILE *out, int nr, const char *call, int macro)
 			size += 4;
 		}
 
-		fprintf(out, "\t%%%i,sp@-\\n\\t\"%s\n", i + 2 - split_flag, macro0);
+		fprintf(out, "\t%%%i,%%sp@-\\n\\t\"%s\n", i + 2 - split_flag, macro0);
 
 		--i;
 	}
 
-	fprintf(out, "\t\t\"movw\t%%%i,sp@-%s\"%s\n", split_flag ? 0 : 1, split_flag ? "" : "\\n\\t", macro0);
+	fprintf(out, "\t\t\"movw\t%%%i,%%sp@-%s\"%s\n", split_flag ? 0 : 1, split_flag ? "" : "\\n\\t", macro0);
 
 	if (!split_flag)
 	{
 		fprintf(out, "\t\t\"trap\t#%i\\n\\t\"%s\n", nr, macro0);
 		if (size <= 8)
-			fprintf(out, "\t\t\"addql\t#%i,sp\"%s\n", size, macro0);
+			fprintf(out, "\t\t\"addql\t#%i,%%sp\"%s\n", size, macro0);
 		else
-			fprintf(out, "\t\t\"lea\tsp@(%i),sp\"%s\n", size, macro0);
+			fprintf(out, "\t\t\"lea\t%%sp@(%i),%%sp\"%s\n", size, macro0);
 
 		fprintf(out, "\t: \"=r\"(retvalue) /* outputs */%s\n", macro0);
 	}
@@ -214,7 +214,7 @@ generate_trap_impl(FILE *out, int nr, const char *call, int macro)
 
 	if (!split_flag)
 	{
-		fprintf(out, "\t: __CLOBBER_RETURN(\"d0\") \"d1\", \"d2\", \"a0\", \"a1\", \"a2\" /* clobbered regs */%s\n", macro0);
+		fprintf(out, "\t: __CLOBBER_RETURN(\"d0\") \"d1\", \"d2\", \"a0\", \"a1\", \"a2\", \"cc\" /* clobbered regs */%s\n", macro0);
 		fprintf(out, "\t  AND_MEMORY%s\n", macro0);
 	}
 
@@ -226,10 +226,10 @@ generate_trap_impl(FILE *out, int nr, const char *call, int macro)
 		fprintf(out, "\t__asm__ volatile%s\n", macro0);
 		fprintf(out, "\t(%s\n", macro0);
 		fprintf(out, "\t\t\"trap\t#%i\\n\\t\"%s\n", nr, macro0);
-		fprintf(out, "\t\t\"lea\tsp@(%i),sp\"%s\n", size, macro0);
+		fprintf(out, "\t\t\"lea\t%%sp@(%i),%%sp\"%s\n", size, macro0);
 		fprintf(out, "\t: \"=r\"(retvalue) /* outputs */%s\n", macro0);
 		fprintf(out, "\t: /* inputs */%s\n", macro0);
-		fprintf(out, "\t: __CLOBBER_RETURN(\"d0\") \"d1\", \"d2\", \"a0\", \"a1\", \"a2\" /* clobbered regs */%s\n", macro0);
+		fprintf(out, "\t: __CLOBBER_RETURN(\"d0\") \"d1\", \"d2\", \"a0\", \"a1\", \"a2\", \"cc\" /* clobbered regs */%s\n", macro0);
 		fprintf(out, "\t  AND_MEMORY%s\n", macro0);
 		fprintf(out, "\t);%s\n", macro0);
 	}

--- a/unix/vfork.S
+++ b/unix/vfork.S
@@ -4,57 +4,60 @@
 | returning to la-la land. Also note that MiNT guarantees that register a1
 | will be preserved across a vfork() system call.
 |
-	.globl	_vfork
-	.globl	___vfork
-	.globl	___mint		| MiNT version kept here
+
+#include "libc-symbols.h"
+
+	.globl	C_SYMBOL_NAME(vfork)
+	.globl	C_SYMBOL_NAME(__vfork)
+	.globl	C_SYMBOL_NAME(__mint)		| MiNT version kept here
 	.lcomm	L_vfsav, 128
 	.text
 	.even
 
-_vfork:
-___vfork:
-	movel	sp@+, a1	| save return address; this is important!
+C_SYMBOL_NAME(vfork):
+C_SYMBOL_NAME(__vfork):
+	movel	%sp@+, %a1	| save return address; this is important!
 #ifdef __MSHORT__
-	tstw	___mint
+	tstw	C_SYMBOL_NAME(__mint)
 # else
-	tstl	___mint
+	tstl	C_SYMBOL_NAME(__mint)
 #endif
 	jeq	L_TOS		| go do the TOS thing
-	movew	#0x113, sp@-	| push MiNT Pvfork() parameter
+	movew	#0x113, %sp@-	| push MiNT Pvfork() parameter
 	trap	#1		| Vfork
-	addql	#2, sp
-	tstl	d0		| error??
+	addql	#2, %sp
+	tstl	%d0		| error??
 	jmi	L_err
-	jmp	a1@		| return
+	jmp	%a1@		| return
 L_TOS:
 #ifdef __mcoldfire__
-	lea	L_vfsav, a0
-	moveml	d2-d7/a1-a6, a0@	| save registers
+	lea	L_vfsav, %a0
+	moveml	%d2-%d7/%a1-%a6, %a0@	| save registers
 #else
-	moveml	d2-d7/a1-a6, L_vfsav	| save registers
+	moveml	%d2-%d7/%a1-%a6, L_vfsav	| save registers
 #endif
 	pea	L_vfsav
-	pea	pc@(L_newprog)
-	jbsr	_tfork		| tfork(L_newprog, L_vfsav)
-	addql	#8, sp
+	pea	%pc@(L_newprog)
+	jbsr	C_SYMBOL_NAME(tfork)		| tfork(L_newprog, L_vfsav)
+	addql	#8, %sp
 #ifdef __mcoldfire__
-	lea	L_vfsav, a0
-	moveml	a0@, d2-d7/a1-a6	| restore reggies
+	lea	L_vfsav, %a0
+	moveml	%a0@, %d2-%d7/%a1-%a6	| restore reggies
 #else
-	moveml	L_vfsav, d2-d7/a1-a6	| restore reggies
+	moveml	L_vfsav, %d2-%d7/%a1-%a6	| restore reggies
 #endif
-	tstl	d0		| fork went OK??
+	tstl	%d0		| fork went OK??
 	jmi	L_err		| no -- error
-	jmp	a1@		| return to caller
+	jmp	%a1@		| return to caller
 L_err:
-	negl	d0
+	negl	%d0
 #ifdef __MSHORT__
-	movew	d0, _errno	| save error code in errno
+	movew	%d0, C_SYMBOL_NAME(errno)	| save error code in errno
 # else
-	movel	d0, _errno	| save error code in errno
+	movel	%d0, C_SYMBOL_NAME(errno)	| save error code in errno
 # endif
-	moveql	#-1, d0		| return -1
-	jmp	a1@		| return
+	moveql	#-1, %d0		| return -1
+	jmp	%a1@		| return
 
 |
 | L_newprog: here is where the child starts executing, with argument
@@ -62,8 +65,8 @@ L_err:
 |
 
 L_newprog:
-	addql	#4, sp		| pop useless return address
-	movel	sp@+, a0	| get address of save area
-	moveml	a0@, d2-d7/a1-a6	| restore reggies
-	clrl	d0		| child always returns 0 from vfork
-	jmp	a1@		| back to caller, as child process
+	addql	#4, %sp		| pop useless return address
+	movel	%sp@+, %a0	| get address of save area
+	moveml	%a0@, %d2-%d7/%a1-%a6	| restore reggies
+	clrl	%d0		| child always returns 0 from vfork
+	jmp	%a1@		| back to caller, as child process


### PR DESCRIPTION
This is necessary to be able to compile the sources using an
elf toolchain, and might also be necessary in the near future
when using newer assembler versions.