### PR TITLE
Fix extern inline semantics for c99

### DIFF
--- a/gmp/dbl2mpn.c
+++ b/gmp/dbl2mpn.c
@@ -16,6 +16,7 @@
    write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
    Boston, MA 02111-1307, USA.  */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/ldbl2mpn.c
+++ b/gmp/ldbl2mpn.c
@@ -16,6 +16,7 @@
    write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
    Boston, MA 02111-1307, USA.  */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/mpn-add_n.c
+++ b/gmp/mpn-add_n.c
@@ -19,6 +19,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 

--- a/gmp/mpn-addmul_1.c
+++ b/gmp/mpn-addmul_1.c
@@ -22,6 +22,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/mpn-cmp.c
+++ b/gmp/mpn-cmp.c
@@ -19,6 +19,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 

--- a/gmp/mpn-divmod_1.c
+++ b/gmp/mpn-divmod_1.c
@@ -25,6 +25,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/mpn-divrem.c
+++ b/gmp/mpn-divrem.c
@@ -20,6 +20,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/mpn-lshift.c
+++ b/gmp/mpn-lshift.c
@@ -19,6 +19,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 

--- a/gmp/mpn-mod_1.c
+++ b/gmp/mpn-mod_1.c
@@ -22,6 +22,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/mpn-mul.c
+++ b/gmp/mpn-mul.c
@@ -19,6 +19,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 

--- a/gmp/mpn-mul_1.c
+++ b/gmp/mpn-mul_1.c
@@ -20,6 +20,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/mpn-mul_n.c
+++ b/gmp/mpn-mul_n.c
@@ -19,6 +19,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 

--- a/gmp/mpn-rshift.c
+++ b/gmp/mpn-rshift.c
@@ -19,6 +19,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 

--- a/gmp/mpn-sub_n.c
+++ b/gmp/mpn-sub_n.c
@@ -19,6 +19,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 

--- a/gmp/mpn-submul_1.c
+++ b/gmp/mpn-submul_1.c
@@ -22,6 +22,7 @@ along with the GNU MP Library; see the file COPYING.LIB.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
 MA 02111-1307, USA. */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include "longlong.h"

--- a/gmp/mpn2dbl.c
+++ b/gmp/mpn2dbl.c
@@ -18,6 +18,7 @@
 
 /* Modified for MiNTLib by Guido Flohr <guido@freemint.de>.  */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include <ieee754.h>

--- a/gmp/mpn2flt.c
+++ b/gmp/mpn2flt.c
@@ -18,6 +18,7 @@
 
 /* Modified for MiNTLib by Guido Flohr <guido@freemint.de>.  */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include <ieee754.h>

--- a/gmp/mpn2ldbl.c
+++ b/gmp/mpn2ldbl.c
@@ -16,6 +16,7 @@
    write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
    Boston, MA 02111-1307, USA.  */
 
+#include <features.h>
 #include "gmp.h"
 #include "gmp-impl.h"
 #include <ieee754.h>

--- a/include/argp.h
+++ b/include/argp.h
@@ -559,7 +559,7 @@ extern void *__argp_input (__const struct argp *__restrict __argp,
 # endif
 
 # ifndef ARGP_EI
-#  define ARGP_EI extern inline
+#  define ARGP_EI _EXTERN_INLINE
 # endif
 
 ARGP_EI void

--- a/include/argz.h
+++ b/include/argz.h
@@ -164,7 +164,7 @@ extern char *argz_next __P ((__const char *__restrict __argz,
 			     __const char *__restrict __entry));
 
 #ifdef __USE_EXTERN_INLINES
-extern inline char *
+_EXTERN_INLINE char *
 __argz_next (__const char *__argz, size_t __argz_len,
 	     __const char *__entry)
 {
@@ -178,7 +178,7 @@ __argz_next (__const char *__argz, size_t __argz_len,
   else
     return __argz_len > 0 ? (char *) __argz : 0;
 }
-extern inline char *
+_EXTERN_INLINE char *
 argz_next (__const char *__argz, size_t __argz_len,
 	   __const char *__entry)
 {

--- a/include/bits/sigset.h
+++ b/include/bits/sigset.h
@@ -43,10 +43,6 @@ typedef unsigned long int __sigset_t;
 #if !defined _SIGSET_H_fns && defined _SIGNAL_H
 #define _SIGSET_H_fns 1
 
-#ifndef _EXTERN_INLINE
-# define _EXTERN_INLINE extern __inline
-#endif
-
 /* Return a mask that includes SIG only.  The cast to `sigset_t' avoids
    overflow if `sigset_t' is wider than `int'.  */
 #define	__sigmask(sig)	(((__sigset_t) 1) << (sig))

--- a/include/bits/socket.h
+++ b/include/bits/socket.h
@@ -214,9 +214,6 @@ struct cmsghdr
 extern struct cmsghdr *__cmsg_nxthdr (struct msghdr *__mhdr,
 				      struct cmsghdr *__cmsg) __THROW;
 #ifdef __USE_EXTERN_INLINES
-# ifndef _EXTERN_INLINE
-#  define _EXTERN_INLINE extern __inline
-# endif
 _EXTERN_INLINE struct cmsghdr *
 __cmsg_nxthdr (struct msghdr *__mhdr, struct cmsghdr *__cmsg)
 {

--- a/include/bits/string2.h
+++ b/include/bits/string2.h
@@ -42,7 +42,7 @@
 #ifdef __cplusplus
 # define __STRING_INLINE inline
 #else
-# define __STRING_INLINE extern __inline
+# define __STRING_INLINE _EXTERN_INLINE
 #endif
 
 #if _STRING_ARCH_unaligned

--- a/include/features.h.in
+++ b/include/features.h.in
@@ -436,9 +436,17 @@
 
 /* Decide whether we can define 'extern inline' functions in headers.  */
 #if __GNUC_PREREQ (2, 7) && defined __OPTIMIZE__ \
-    && !defined __OPTIMIZE_SIZE__ && !defined __NO_INLINE__ \
-    && !defined __GNUC_STDC_INLINE__
+    && !defined __OPTIMIZE_SIZE__ && !defined __NO_INLINE__
 # define __USE_EXTERN_INLINES	1
+# if (defined __GNUC_STDC_INLINE__ && __GNUC_STDC_INLINE__) || \
+     defined __cplusplus || \
+     (defined __clang__ && (defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__))
+#   define _EXTERN_INLINE extern __inline __attribute__((__gnu_inline__))
+# else
+#   define _EXTERN_INLINE extern __inline
+# endif
+#else
+# define _EXTERN_INLINE extern
 #endif
 
 #endif	/* features.h  */

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -307,14 +307,14 @@ __extension__ extern lldiv_t lldiv __P ((long long int __numer,
 
 
 /* Compute absolute value of N.  */
-extern __inline intmax_t
+_EXTERN_INLINE intmax_t
 imaxabs (intmax_t __n)
 {
   return llabs (__n);
 }
 
 /* Return the `imaxdiv_t' representation of the value of NUMER over DENOM. */
-extern __inline imaxdiv_t
+_EXTERN_INLINE imaxdiv_t
 imaxdiv (intmax_t __numer, intmax_t __denom)
 {
   return lldiv (__numer, __denom);
@@ -328,7 +328,7 @@ extern long long int __strtoll_internal __P ((__const char *__restrict __nptr,
 					      int __base, int __group));
 #  define __strtoll_internal_defined	1
 # endif
-extern __inline intmax_t
+_EXTERN_INLINE intmax_t
 strtoimax (__const char *__restrict nptr, char **__restrict endptr,
 	   int base)
 {
@@ -346,7 +346,7 @@ extern unsigned long long int __strtoull_internal __P ((__const char *
 							int __group));
 #  define __strtoull_internal_defined	1
 # endif
-extern __inline uintmax_t
+_EXTERN_INLINE uintmax_t
 strtoumax (__const char *__restrict nptr, char **__restrict endptr,
 	   int base)
 {
@@ -363,7 +363,7 @@ extern long long int __wcstoll_internal __P ((__const wchar_t *
 					      int __base, int __group));
 #  define __wcstoll_internal_defined	1
 # endif
-extern __inline intmax_t
+_EXTERN_INLINE intmax_t
 wcstoimax (__const wchar_t *__restrict nptr, wchar_t **__restrict endptr,
 	   int base) __THROW
 {
@@ -382,7 +382,7 @@ extern unsigned long long int __wcstoull_internal __P ((__const wchar_t *
 							int __group));
 #  define __wcstoull_internal_defined	1
 # endif
-extern __inline uintmax_t
+_EXTERN_INLINE uintmax_t
 wcstoumax (__const wchar_t *__restrict nptr, wchar_t **__restrict endptr,
 	   int base) __THROW
 {

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -424,7 +424,7 @@ extern int vsprintf __P ((char *__restrict __s,
 			  __gnuc_va_list __arg));
 
 #ifdef __USE_EXTERN_INLINES
-extern __inline int
+_EXTERN_INLINE int
 vprintf (const char *__restrict __fmt, __gnuc_va_list __arg)
 {
   return vfprintf (stdout, __fmt, __arg);
@@ -498,17 +498,17 @@ extern int vsscanf __P ((__const char *__s, __const char *__format,
 
 
 #ifdef __USE_EXTERN_INLINES
-extern __inline int
+_EXTERN_INLINE int
 vfscanf (FILE *__s, const char *__fmt, __gnuc_va_list __arg)
 {
   return __vfscanf (__s, __fmt, __arg);
 }
-extern __inline int
+_EXTERN_INLINE int
 vscanf (const char *__fmt, __gnuc_va_list __arg)
 {
   return __vfscanf (stdin, __fmt, __arg);
 }
-extern __inline int
+_EXTERN_INLINE int
 vsscanf (const char *__s, const char *__fmt, __gnuc_va_list __arg)
 {
   return __vsscanf (__s, __fmt, __arg);
@@ -540,7 +540,7 @@ extern int getchar __P ((void));
 #define	getc(stream)	__getc(stream)
 
 #ifdef __USE_EXTERN_INLINES
-extern __inline int
+_EXTERN_INLINE int
 getchar (void)
 {
   return __getc (stdin);
@@ -553,13 +553,13 @@ extern int getc_unlocked __P ((FILE *__stream));
 extern int getchar_unlocked __P ((void));
 
 # ifdef __USE_EXTERN_INLINES
-extern __inline int
+_EXTERN_INLINE int
 getc_unlocked (FILE *__stream)
 {
   return __getc (__stream);
 }
 
-extern __inline int
+_EXTERN_INLINE int
 getchar_unlocked (void)
 {
   return __getc (stdin);
@@ -588,7 +588,7 @@ extern int putchar __P ((int __c));
 #define	putc(c, stream)	__putc ((c), (stream))
 
 #ifdef __USE_EXTERN_INLINES
-extern __inline int
+_EXTERN_INLINE int
 putchar (int __c)
 {
   return __putc (__c, stdout);
@@ -600,7 +600,7 @@ putchar (int __c)
 extern int fputc_unlocked __P ((int __c, FILE *__stream));
 
 # ifdef __USE_EXTERN_INLINES
-extern __inline int
+_EXTERN_INLINE int
 fputc_unlocked (int __c, FILE *__stream)
 {
   return __putc (__c, __stream);
@@ -614,13 +614,13 @@ extern int putc_unlocked __P ((int __c, FILE *__stream));
 extern int putchar_unlocked __P ((int __c));
 
 # ifdef __USE_EXTERN_INLINES
-extern __inline int
+_EXTERN_INLINE int
 putc_unlocked (int __c, FILE *__stream)
 {
   return __putc (__c, __stream);
 }
 
-extern __inline int
+_EXTERN_INLINE int
 putchar_unlocked (int __c)
 {
   return __putc (__c, stdout);
@@ -671,7 +671,7 @@ ssize_t __getline __P ((char **__lineptr, size_t *__n, FILE *__stream));
 ssize_t getline __P ((char **__lineptr, size_t *__n, FILE *__stream));
 
 #ifdef __USE_EXTERN_INLINES
-extern __inline ssize_t
+_EXTERN_INLINE ssize_t
 getline (char **__lineptr, size_t *__n, FILE *__stream)
 {
   return __getdelim (__lineptr, __n, '\n', __stream);

--- a/mintlib/_itoa.h
+++ b/mintlib/_itoa.h
@@ -22,7 +22,7 @@
    Return the address of the first (left-to-right) character in the number.
    Use upper case letters iff UPPER_CASE is nonzero.  */
 
-extern __inline char * __attribute__ ((unused))
+_EXTERN_INLINE char * __attribute__ ((unused))
 _itoa_word (unsigned long value, char *buflim,
 	    unsigned int base, int upper_case)
 {
@@ -51,7 +51,7 @@ _itoa_word (unsigned long value, char *buflim,
   return bp;
 }
 
-extern __inline char * __attribute__ ((unused))
+_EXTERN_INLINE char * __attribute__ ((unused))
 _fitoa_word (unsigned long value, char *buf, unsigned int base, int upper_case)
 {
   char tmpbuf[sizeof value * 4];	/* Worst case length: base 2.  */
@@ -61,7 +61,7 @@ _fitoa_word (unsigned long value, char *buf, unsigned int base, int upper_case)
   return buf;
 }
 
-extern __inline char * __attribute__ ((unused))
+_EXTERN_INLINE char * __attribute__ ((unused))
 _fitoa (unsigned long long value, char *buf, unsigned int base, int upper_case)
 {
   char tmpbuf[sizeof value * 4];	/* Worst case length: base 2.  */

--- a/stdio/_itoa.c
+++ b/stdio/_itoa.c
@@ -19,6 +19,7 @@
    write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
    Boston, MA 02111-1307, USA.  */
 
+#include <features.h>
 #include <gmp-mparam.h>
 #include <stdlib/gmp.h>
 #include <stdlib/gmp-impl.h>

--- a/stdio/linewrap.h
+++ b/stdio/linewrap.h
@@ -66,7 +66,7 @@ void line_unwrap_stream (FILE *stream);
 
 #ifdef __OPTIMIZE__
 /* Returns true if STREAM is line wrapped.  */
-extern __inline int line_wrapped (FILE *stream);
+_EXTERN_INLINE int line_wrapped (FILE *stream);
 #endif
 
 /* If STREAM is not line-wrapped return -1, else return its left margin.  */
@@ -107,14 +107,14 @@ extern void __line_wrap_output (FILE *, int); /* private */
 extern struct line_wrap_data *__line_wrap_update (FILE *stream); /* private */
 
 /* Returns true if STREAM is line wrapped.  */
-extern __inline int
+_EXTERN_INLINE int
 line_wrapped (FILE *stream)
 {
   return (stream->__room_funcs.__output == &__line_wrap_output);
 }
 
 /* If STREAM is not line-wrapped return -1, else return its left margin.  */
-extern __inline size_t
+_EXTERN_INLINE size_t
 line_wrap_lmargin (FILE *stream)
 {
   if (! line_wrapped (stream))
@@ -124,7 +124,7 @@ line_wrap_lmargin (FILE *stream)
 
 /* If STREAM is not line-wrapped return -1, else set its left margin to
    LMARGIN and return the old value.  */
-extern __inline size_t
+_EXTERN_INLINE size_t
 line_wrap_set_lmargin (FILE *stream, size_t lmargin)
 {
   struct line_wrap_data *d = __line_wrap_update (stream);
@@ -139,7 +139,7 @@ line_wrap_set_lmargin (FILE *stream, size_t lmargin)
 }
 
 /* If STREAM is not line-wrapped return -1, else return its left margin.  */
-extern __inline size_t
+_EXTERN_INLINE size_t
 line_wrap_rmargin (FILE *stream)
 {
   if (! line_wrapped (stream))
@@ -149,7 +149,7 @@ line_wrap_rmargin (FILE *stream)
 
 /* If STREAM is not line-wrapped return -1, else set its right margin to
    RMARGIN and return the old value.  */
-extern __inline size_t
+_EXTERN_INLINE size_t
 line_wrap_set_rmargin (FILE *stream, size_t rmargin)
 {
   struct line_wrap_data *d = __line_wrap_update (stream);
@@ -164,7 +164,7 @@ line_wrap_set_rmargin (FILE *stream, size_t rmargin)
 }
 
 /* If STREAM is not line-wrapped return -1, else return its wrap margin.  */
-extern __inline size_t
+_EXTERN_INLINE size_t
 line_wrap_wmargin (FILE *stream)
 {
   if (! line_wrapped (stream))
@@ -174,7 +174,7 @@ line_wrap_wmargin (FILE *stream)
 
 /* If STREAM is not line-wrapped return -1, else set its left margin to
    WMARGIN and return the old value.  */
-extern __inline size_t
+_EXTERN_INLINE size_t
 line_wrap_set_wmargin (FILE *stream, size_t wmargin)
 {
   struct line_wrap_data *d = __line_wrap_update (stream);
@@ -190,7 +190,7 @@ line_wrap_set_wmargin (FILE *stream, size_t wmargin)
 
 /* If STREAM is not line-wrapped return -1, else return the column number of
    the current output point.  */
-extern __inline size_t
+_EXTERN_INLINE size_t
 line_wrap_point (FILE *stream)
 {
   struct line_wrap_data *d = __line_wrap_update (stream);


### PR DESCRIPTION
The previous attempt of using -fgnu89-inline works when compiling
the library, but not when compiling other packages using newer
compiler versions that default to c99 inline semantics