### PR TITLE
Update processor defines to gcc generic ones

### DIFF
--- a/include/bits/string.h
+++ b/include/bits/string.h
@@ -23,7 +23,7 @@
 # error "Never use <bits/string.h> directly; include <string.h> instead."
 #endif
 
-#if defined(__mc68020__) || defined(__mcoldfire__)
+#if defined(__mc68020__) || defined(__mc68030__) || defined(__mc68040__) || defined(__mc68060__) || defined(__mcoldfire__)
 /* Currently the only purpose of this file is to tell the generic inline
    macros that unaligned memory access is possible.  */
 # define _STRING_ARCH_unaligned	1

--- a/mintlib/atomicity.h
+++ b/mintlib/atomicity.h
@@ -24,7 +24,7 @@
 
 #include <inttypes.h>
 
-#ifdef __mc68020__
+#if defined(__mc68020__) || defined(__mc68030__) || defined(__mc68040__) || defined(__mc68060__)
 # include "atomicity-68020.h"
 #else
 static inline int

--- a/mintlib/checkcpu.S
+++ b/mintlib/checkcpu.S
@@ -24,7 +24,7 @@
 
 	.globl	__checkcpu
 __checkcpu:
-#ifdef __mc68020__
+#if defined(__mc68020__) || defined(__mc68030__) || defined(__mc68040__) || defined(__mc68060__)
 	subql	#4,sp			| Local variable for cookie value
 
 	pea	sp@

--- a/mintlib/ident.c
+++ b/mintlib/ident.c
@@ -1,7 +1,7 @@
 #include <features.h>
 
 char __Ident_gnulib[] = "$Version: MiNTLib "
-#ifdef __mc68020__
+#if defined(__mc68020__) || defined(__mc68030__) || defined(__mc68040__) || defined(__mc68060__)
 "-m68020-60 "
 #endif
 #ifdef __mcoldfire__

--- a/mintlib/memcopy.h
+++ b/mintlib/memcopy.h
@@ -171,7 +171,7 @@ extern void _wordcopy_bwd_dest_aligned __P ((long int, long int, size_t));
 /* It's already included above for the MiNTLib.  */
 /* #include <sysdeps/generic/memcopy.h> */
 
-#if	defined(__mc68020__)
+#if defined(__mc68020__) || defined(__mc68030__) || defined(__mc68040__) || defined(__mc68060__)
 
 #undef	OP_T_THRES
 #define	OP_T_THRES	16

--- a/stdlib/longlong.h
+++ b/stdlib/longlong.h
@@ -533,7 +533,8 @@ extern USItype __udiv_qrnnd ();
 	     "d" ((USItype)(bh)),					\
 	     "1" ((USItype)(al)),					\
 	     "g" ((USItype)(bl)))
-#if (defined (__mc68020__) || defined (__NeXT__))
+#if (defined (__mc68020__) || defined(__mc68030__) || defined(__mc68040__) \
+  || defined(__mc68060__) || defined (__NeXT__))
 #define umul_ppmm(w1, w0, u, v) \
   __asm__ ("mulu%.l %3,%1:%0"						\
 	   : "=d" ((USItype)(w0)),					\


### PR DESCRIPTION
For the first commit I didn't add the defines for 68030, 68040 and 68060 because MiNTlib isn't build particularly for those processors but for the range 020-60, and __mc68020__ is defined then. But please note that the deprecated __M68020__ was defined even when the compiler was making code specifically for any of those CPUs.  