### PR TITLE
Add fallback for the port finding in getaddrinfo()

### DIFF
--- a/socket/getaddrinfo.c
+++ b/socket/getaddrinfo.c
@@ -181,12 +181,20 @@ int __getaddrinfo(const char *node, const char *service, const struct addrinfo *
 	{
 		unsigned long d;
 		char *end;
+		struct servent *sp;
 
 		d = strtoul(service, &end, 0);
-		if (end[0] || d > 65535u)
-			return EAI_SERVICE;
-
-		port = htons((uint16_t) d);
+		if (!end[0]) {
+			if (d > 65535)
+				return (EAI_SERVICE);
+			port = htons((unsigned short) d);
+		} else
+		{
+			sp = getservbyname(service, NULL);
+			if (sp == NULL)
+				return (EAI_SERVICE);
+			port = sp->s_port;
+		}
 	}
 
 	/* building results... */


### PR DESCRIPTION
Sometimes the service's port number is not included in the
string passed as the second function's parameter, in those
cases we have now a plan B where we look for the port number
using the function getservbyname().

ntpdate is an example of a program that doesn't include the port
number in the service string. ntpdate own implementation of
getaddrinfo() uses getservbyname() to find out the port
number of the service.