### PR TITLE
Avoid hardcoding gcc

### DIFF
--- a/syscall/Makefile
+++ b/syscall/Makefile
@@ -44,7 +44,7 @@ syscalls.stmp: gen-syscall0 syscalls.master
 	touch $@
 
 gen-syscall0:
-	$(MAKE) gen-syscall CC="gcc" CFLAGS="-O -Wall" COMPILE="gcc -O -Wall"
+	$(MAKE) gen-syscall CC="$(CC_FOR_BUILD)" CFLAGS="-O -Wall" COMPILE="$(CC_FOR_BUILD) -O -Wall"
 
 gen-syscall: $(gen_objs)
 	$(CC) $(gen_objs) -o $@ -lfl


### PR DESCRIPTION
This causes problems in Travis/OSX as on OS X the gcc is a frontend to llvm