### PR TITLE
Allow CC, CFLAGS and LDFLAGS for build be overriden

### DIFF
--- a/tz/private.h
+++ b/tz/private.h
@@ -141,6 +141,21 @@
 #include "time.h"
 #include "stdlib.h"
 
+/*
+** Header files above silently include either "../include/features.h" or <features.h>
+** what is a mintlib/glibc specific file and may not be present in other libc
+** implementations. As we use __GNUC_PREREQ below (which is defined in features.h)
+** we must provide it here.
+*/
+#ifndef __GNUC_PREREQ
+#if defined __GNUC__ && defined __GNUC_MINOR__
+# define __GNUC_PREREQ(maj, min) \
+        ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+#else
+# define __GNUC_PREREQ(maj, min) 0
+#endif
+#endif
+
 #ifdef ENABLE_NLS
 #include "locale.h"	/* for setlocale */
 #include "libintl.h"


### PR DESCRIPTION
This is useful for testing/building, i.e. one can call `CC_FOR_BUILD=gcc-4.9 make`.

`syscall/Makefile` actually has support for `make CC_FOR_BUILD=gcc-4.9` but `tz/Makefile` does not and it seemed like too much hassle to change.