### PR TITLE
Fix generating bison output for pars.y

### DIFF
--- a/syscall/Makefile
+++ b/syscall/Makefile
@@ -49,7 +49,7 @@ gen-syscall: $(gen_objs)
 	$(CC) $(gen_objs) -o $@
 
 pars.c pars.h: pars.y
-	if bison --defines=pars.h.tmp$$$$ --output=pars.c $<; then mv pars.h.tmp$$$$ pars.h; else rm -f pars.h.tmp$$$$; exit 1; fi
+	bison --defines=pars.h --output=pars.c $< || (rm -f pars.h; exit 1)
 
 pars.o: pars.c pars.h
 


### PR DESCRIPTION
The generated `pars.c` file requires the header file specified by the `--defines` argument, but it's renamed before the source file can be compiled.