### PR TITLE
Add set_sysvar_to_short and fix compiler warnings

### DIFF
--- a/include/mint/sysvars.h
+++ b/include/mint/sysvars.h
@@ -120,8 +120,9 @@ typedef struct _osheader
 
 /* zzzz to-do more */
 
-extern long get_sysvar (volatile void *var) __THROW;
-extern void set_sysvar_to_long (void *var, long val) __THROW;
+extern long get_sysvar (const volatile void *var) __THROW;
+extern void set_sysvar_to_short (volatile void *var, short val) __THROW;
+extern void set_sysvar_to_long (volatile void *var, long val) __THROW;
 
 
 __END_DECLS

--- a/mintlib/getcookie.S
+++ b/mintlib/getcookie.S
@@ -20,7 +20,7 @@
 #include "libc-symbols.h"
 
 	.extern	C_SYMBOL_NAME(__has_no_ssystem)	| int __has_no_ssystem;
-	.extern	C_SYMBOL_NAME(get_sysvar)		| long get_sysvar(void *var);
+	.extern	C_SYMBOL_NAME(get_sysvar)		| long get_sysvar(const volatile void *var);
 
 	.globl	C_SYMBOL_NAME(Getcookie)
 C_SYMBOL_NAME(Getcookie):

--- a/mintlib/getsysvar.S
+++ b/mintlib/getsysvar.S
@@ -6,7 +6,7 @@
 | this file you indicate that you have read the license and
 | understand and accept it fully.
 
-| long get_sysvar(void *var);
+| long get_sysvar(const volatile void *var);
 |
 | Read an OS variable.
 |

--- a/mintlib/setsysvar.c
+++ b/mintlib/setsysvar.c
@@ -7,7 +7,21 @@
 #include "lib.h"
 
 void
-set_sysvar_to_long (void *var, long val)
+set_sysvar_to_short (volatile void *var, short val)
+{
+	if(__has_no_ssystem) {
+		long save_ssp;
+
+    		save_ssp = (long) Super((void *) 0L);
+    		*((volatile short *)var) = val;
+    		(void)SuperToUser((void *) save_ssp);
+	}
+	else
+		(void) Ssystem (S_SETWVAL, var, val); /* note: root only! */
+}
+
+void
+set_sysvar_to_long (volatile void *var, long val)
 {
 	if(__has_no_ssystem) {
 		long save_ssp;


### PR DESCRIPTION
As all sysvars are marked as volatile, the compiler complained about discarding the `volatile` qualifier when passing variables from `sysvars.h`.