### PR TITLE
Minimal implementation of clock_nanosleep function

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -279,6 +279,9 @@ extern int nanosleep (__const struct timespec *__requested_time,
 		      struct timespec *__remaining);
 
 extern int clock_gettime(clockid_t clock_id, struct timespec *tp);
+
+extern int clock_nanosleep (clockid_t clock_id, int flags, const struct timespec *req, 
+            struct timespec *rem);
 # endif
 
 # ifdef __USE_XOPEN_EXTENDED

--- a/posix/SRCFILES
+++ b/posix/SRCFILES
@@ -21,6 +21,7 @@ SRCFILES = \
 	isfdtype.c \
 	nanosleep.c \
 	clock_gettime.c \
+	clock_nanosleep.c \
 	posix_fallocate.c \
 	pread.c \
 	pwrite.c \

--- a/posix/clock_nanosleep.c
+++ b/posix/clock_nanosleep.c
@@ -1,0 +1,80 @@
+/* High-resolution sleep with the specified clock.
+   Copyright (C) 2000-2012 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <assert.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/time.h>
+
+__typeof__(clock_nanosleep) __clock_nanosleep;
+
+/* This implementation assumes that these is only a `nanosleep' system
+   call.  So we have to remap all other activities.  */
+int
+__clock_nanosleep (clockid_t clock_id, int flags, const struct timespec *req, struct timespec *rem)
+{
+    struct timespec now;
+
+    if (__builtin_expect (req->tv_nsec, 0) < 0 || __builtin_expect (req->tv_nsec, 0) >= 1000000000){
+        return EINVAL;
+    }
+
+    /* If we got an absolute time, remap it.  */
+    if (flags == TIMER_ABSTIME)
+    {
+        long int nsec;
+        long int sec;
+
+        /* Make sure we use safe data types.  */
+        assert (sizeof (sec) >= sizeof (now.tv_sec));
+
+        /* Get the current time for this clock.  */
+        if (__builtin_expect (clock_gettime (clock_id, &now), 0) != 0){
+            return errno;
+        }
+
+        /* Compute the difference.  */
+        nsec = req->tv_nsec - now.tv_nsec;
+        sec = req->tv_sec - now.tv_sec - (nsec < 0);
+
+        if (sec < 0){
+            /* The time has already elapsed.  */
+            return 0;
+        }
+
+        now.tv_sec = sec;
+        now.tv_nsec = nsec + (nsec < 0 ? 1000000000 : 0);
+
+        /* From now on this is our time.  */
+        req = &now;
+
+        /* Make sure we are not modifying the struct pointed to by REM.  */
+        rem = NULL;
+    }
+    else if (__builtin_expect (flags, 0) != 0){
+        return EINVAL;
+    }
+    else if (clock_id != CLOCK_REALTIME){
+        /* Not supported.  */
+        return ENOTSUP;
+    }
+
+    return __builtin_expect (nanosleep (req, rem), 0) ? errno : 0;
+}
+
+weak_alias (__clock_nanosleep, clock_nanosleep)

--- a/posix/clock_nanosleep.c
+++ b/posix/clock_nanosleep.c
@@ -69,7 +69,7 @@ __clock_nanosleep (clockid_t clock_id, int flags, const struct timespec *req, st
     else if (__builtin_expect (flags, 0) != 0){
         return EINVAL;
     }
-    else if (clock_id != CLOCK_REALTIME){
+    else if ((clock_id != CLOCK_REALTIME) && clock_id != CLOCK_MONOTONIC){
         /* Not supported.  */
         return ENOTSUP;
     }


### PR DESCRIPTION
Tested with attached codes grabbed from [here](https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-libraries/winpthreads/tests/t_clock_nanosleep.c), [here](https://code.videolan.org/ePirat/vlc-legacy/-/merge_requests/16/diffs?commit_id=935875b3d82640bdb79c59cb2e4f7232759a51c0) and [here](https://elixir.free-electrons.com/glibc/glibc-2.23.90/source/rt/tst-clock_nanosleep.c) but still searching for more test code.

I've the same behavior on Freemint & Ubuntu.

[test_nanosleep.c.zip](https://github.com/user-attachments/files/17269988/test_nanosleep.c.zip)
[test_nanosleep_2.c.zip](https://github.com/user-attachments/files/17270121/test_nanosleep_2.c.zip)
[test_nanosleep_3.c.zip](https://github.com/user-attachments/files/17270255/test_nanosleep_3.c.zip)

<img width="1092" alt="Capture d’écran 2024-10-06 à 17 43 10" src="https://github.com/user-attachments/assets/88228b1e-ba49-42fe-bda5-5c56e3aa48a2">
